### PR TITLE
Syncs latest docs from Terrascan repo

### DIFF
--- a/content/en/docs/Policies/aws.md
+++ b/content/en/docs/Policies/aws.md
@@ -3,293 +3,394 @@ title: "AWS Policies"
 linkTitle: "AWS Policies"
 weight: 20
 description: >
-      
+
 ---
 
 ### aws_iam_role_policy
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Identity and Access Management | IamPolicy | HIGH | It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges. | AWS.IamPolicy.IAM.High.0392 |
+| Identity and Access Management | json | HIGH | It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges. | AC-AW-IA-H-1189 |
+| Identity and Access Management | AIRP | HIGH | Ensure IAM roles do not have any policies attached that may cause privilege escalation. | AWS.AIRP.IAM.HIGH.0051 |
 
 
 ### aws_route53_record
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| DNS Management | Route53HostedZone | HIGH | Route53HostedZone should have recordSets. | AWS.Route53HostedZone.DNSManagement.High.0422 |
+| Logging and Monitoring | Route53HostedZone | HIGH | Route53HostedZone should have recordSets. | AWS.Route53HostedZone.DNSManagement.High.0422 |
+
+
+### aws_elasticsearch_domain_policy
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Identity and Access Management | AEDP | HIGH | Ensure Elasticsearch domains do not have wildcard policies. | AWS.AEDP.IAM.HIGH.0060 |
+
+
+### aws_lb_target_group
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Infrastructure Security | ALTG | MEDIUM | Ensure Target Group use HTTPs to ensure end to end encryption | AWS.ALTG.IS.MEDIUM.0042 |
 
 
 ### aws_api_gateway_method_settings
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Logging | API Gateway | MEDIUM | Enable Detailed CloudWatch Metrics for APIs | AWS.API Gateway.Logging.Medium.0569 |
+| Logging and Monitoring | API Gateway | MEDIUM | Enable Detailed CloudWatch Metrics for APIs | AWS.APIGateway.Logging.Medium.0569 |
+
+
+### aws_workspaces_workspace
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Data Protection | AWW | MEDIUM | Ensure user volume for Workspaces is Encrypted | AWS.AWW.DP.MEDIUM.041 |
+| Data Protection | AWW | MEDIUM | Ensure root volume for Workspaces is Encrypted | AWS.AWW.DP.MEDIUM.040 |
 
 
 ### aws_vpc
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Logging | VPC | MEDIUM | Avoid creating resources in default VPC | AWS.VPC.Logging.Medium.0471 |
-| Logging | VPC | MEDIUM | Ensure VPC flow logging is enabled in all VPCs | AWS.VPC.Logging.Medium.0470 |
+| Security Best Practices | VPC | MEDIUM | Avoid creating resources in default VPC | AWS.VPC.Logging.Medium.0471 |
+| Logging and Monitoring | VPC | LOW | Ensure VPC flow logging is enabled in all VPCs | AWS.VPC.Logging.Medium.0470 |
 
 
 ### aws_iam_account_password_policy
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| IAM | Iam | MEDIUM | Lower case alphabet not present in the Password, Password Complexity is not high. Increased Password complexity increases resiliency against brute force attack | AWS.Iam.IAM.Medium.0454 |
-| IAM | Iam | MEDIUM | Setting a lengthy password increases account resiliency against brute force login attempts | AWS.Iam.IAM.Medium.0458 |
-| IAM | Iam | LOW | It is recommended that the password policy prevent the reuse of passwords.Preventing password reuse increases account resiliency against brute force login attempts | AWS.Iam.IAM.Low.0539 |
-| IAM | Iam | MEDIUM | Number not present in the Password, Password Complexity is not high. Increased Password complexity increases resiliency against brute force attack | AWS.Iam.IAM.Medium.0455 |
-| IAM | Iam | MEDIUM | Setting a lengthy password increases account resiliency against brute force login attempts | AWS.Iam.IAM.Medium.0495 |
-| IAM | Iam | MEDIUM | Special symbols not present in the Password, Password Complexity is not high. Increased Password complexity increases resiliency against brute force attack | AWS.Iam.IAM.Medium.0456 |
-| IAM | Iam | MEDIUM | Upper case alphabet not present in the Password, Password Complexity is not high. Increased Password complexity increases resiliency against brute force attack | AWS.Iam.IAM.Medium.0457 |
-| IAM | Iam | LOW | Reducing the password lifetime increases account resiliency against brute force login attempts | AWS.Iam.IAM.Low.0540 |
+| Compliance Validation | Iam | LOW | Lower case alphabet not present in the Password, Password Complexity is not high. Increased Password complexity increases resiliency against brute force attack | AWS.Iam.IAM.Medium.0454 |
+| Compliance Validation | Iam | MEDIUM | Setting a lengthy password increases account resiliency against brute force login attempts | AWS.Iam.IAM.Medium.0458 |
+| Compliance Validation | Iam | LOW | It is recommended that the password policy prevent the reuse of passwords.Preventing password reuse increases account resiliency against brute force login attempts | AWS.Iam.IAM.Low.0539 |
+| Compliance Validation | Iam | MEDIUM | Number not present in the Password, Password Complexity is not high. Increased Password complexity increases resiliency against brute force attack | AWS.Iam.IAM.Medium.0455 |
+| Compliance Validation | Iam | MEDIUM | Setting a lengthy password increases account resiliency against brute force login attempts | AWS.Iam.IAM.Medium.0495 |
+| Compliance Validation | Iam | MEDIUM | Special symbols not present in the Password, Password Complexity is not high. Increased Password complexity increases resiliency against brute force attack | AWS.Iam.IAM.Medium.0456 |
+| Compliance Validation | Iam | MEDIUM | Upper case alphabet not present in the Password, Password Complexity is not high. Increased Password complexity increases resiliency against brute force attack | AWS.Iam.IAM.Medium.0457 |
+| Compliance Validation | Iam | LOW | Reducing the password lifetime increases account resiliency against brute force login attempts | AWS.Iam.IAM.Low.0540 |
 
 
 ### aws_mq_broker
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | ElasticSearch | MEDIUM | Publicly Accessible MQ Brokers | AWS.ElasticSearch.NetworkSecurity.Medium.0887 |
-| Logging | ElasticSearch | MEDIUM | Enable AWS MQ Log Exports | AWS.ElasticSearch.Logging.Medium.0885 |
+| Security Best Practices | ElasticSearch | MEDIUM | Publicly Accessible MQ Brokers | AWS.ElasticSearch.NetworkSecurity.Medium.0887 |
+| Logging and Monitoring | ElasticSearch | LOW | Enable AWS MQ Log Exports | AWS.ElasticSearch.Logging.Medium.0885 |
 
 
 ### aws_db_instance
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | AWS RDS | HIGH | RDS Instance publicly_accessible flag is true | AWS.AWS RDS.NS.High.0101 |
-| Data Security | RDS | HIGH | Ensure Certificate used in RDS instance is updated | AWS.RDS.DS.High.1042 |
-| Data Security | RDS | HIGH | Ensure that your RDS database has IAM Authentication enabled. | AWS.RDS.DataSecurity.High.0577 |
-| Data Security | RDS | HIGH | RDS Instance Auto Minor Version Upgrade flag disabled | AWS.RDS.DS.High.1041 |
-| Data Security | RDS | HIGH | Ensure that your RDS database instances have automated backups enabled for point-in-time recovery. To back up your database instances, AWS RDS take automatically a full daily snapshot of your data (with transactions logs) during the specified backup window and keeps the backups for a limited period of time (known as retention period) defined by the instance owner. | AWS.RDS.DataSecurity.High.0414 |
+| Data Protection | RDS | HIGH | Ensure Certificate used in RDS instance is updated | AWS.RDS.DS.High.1042 |
+| Logging and Monitoring | ADI | MEDIUM | Ensure AWS RDS instances have logging enabled. | AWS.ADI.LM.MEDIUM.0076 |
+| Data Protection | RDS | MEDIUM | Ensure that your RDS database has IAM Authentication enabled. | AWS.RDS.DataSecurity.High.0577 |
+| Infrastructure Security | RDS | HIGH | RDS Instance publicly_accessible flag is true | AWS.RDS.NS.High.0101 |
+| Data Protection | RDS | HIGH | RDS Instance Auto Minor Version Upgrade flag disabled | AWS.RDS.DS.High.1041 |
+| Data Protection | RDS | HIGH | Ensure that your RDS database instances encrypt the underlying storage. Encrypted RDS instances use the industry standard AES-256 encryption algorithm to encrypt data on the server that hosts RDS DB instances. After data is encrypted, RDS handles authentication of access and descryption of data transparently with minimal impact on performance. | AWS.RDS.DataSecurity.High.0414 |
+
+
+### aws_secretsmanager_secret_policy
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Identity and Access Management | ASSP | HIGH | Ensure secrets manager do not wildcard policies attached | AWS.ASSP.IAM.HIGH.0066 |
 
 
 ### aws_ebs_volume
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | EcsCluster | HIGH | Ensure that AWS EBS clusters are encrypted. Data encryption at rest, prevents unauthorized users from accessing sensitive data on your AWS EBS clusters and associated cache storage systems. | AWS.EcsCluster.EncryptionandKeyManagement.High.0413 |
-| Encryption and Key Management | EBS | HIGH | Enable AWS EBS Snapshot Encryption | AWS.EBS.EKM.Medium.0682 |
+| Data Protection | EcsCluster | HIGH | Ensure that AWS EBS clusters are encrypted. Data encryption at rest, prevents unauthorized users from accessing sensitive data on your AWS EBS clusters and associated cache storage systems. | AWS.EcsCluster.EncryptionandKeyManagement.High.0413 |
+| Data Protection | EBS | HIGH | Enable AWS EBS Snapshot Encryption | AWS.EBS.EKM.Medium.0682 |
 
 
 ### aws_api_gateway_rest_api
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-|   | APIGateway | MEDIUM | Enable Content Encoding | AWS.APIGateway.Medium.0568 |
-| Network Security | APIGateway | MEDIUM | API Gateway Private Endpoints | AWS.APIGateway.Network Security.Medium.0570 |
+| Infrastructure Security | APIGateway | MEDIUM | Enable Content Encoding | AWS.APIGateway.Medium.0568 |
+| Infrastructure Security | APIGateway | MEDIUM | API Gateway Private Endpoints | AWS.APIGateway.NetworkSecurity.Medium.0570 |
 
 
 ### aws_iam_role
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Identity and Access Management | IamPolicy | HIGH | It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges. | AWS.IamPolicy.IAM.High.0392 |
+| Identity and Access Management | json | HIGH | It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges. | AC-AW-IA-H-1188 |
+
+
+### aws_iam_user_policy_attachment
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Identity and Access Management | AIUPA | MEDIUM | Ensure IAM permissions are not given directly to users | AWS.AIUPA.IAM.MEDIUM.0050 |
 
 
 ### aws_ebs_encryption_by_default
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Data Security | EBS | HIGH | Ensure that the AWS EBS that hold sensitive and critical data is encrypted by default to fulfill compliance requirements for data-at-rest encryption. | AWS.EBS.DataSecurity.High.0580 |
+| Data Protection | EBS | HIGH | Ensure that the AWS EBS that hold sensitive and critical data is encrypted by default to fulfill compliance requirements for data-at-rest encryption. | AWS.EBS.DataSecurity.High.0580 |
 
 
 ### aws_sns_topic
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | SNS | MEDIUM | Ensure SNS Topic is Publicly Accessible For Subscription | AWS.SNS.NS.Medium.1044 |
+| Compliance Validation | SNS | HIGH | Ensure SNS Topic is Publicly Accessible For Subscription | AWS.SNS.NS.Medium.1044 |
+| Data Protection | AST | MEDIUM | Ensure SNS topic is Encrypted using KMS master key | AWS.AST.DP.MEDIUM.0037 |
 
 
 ### aws_apigatewayv2_api
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| AccessControl | ApiGatewayV2Api | Medium | Insecure Cross-Origin Resource Sharing Configuration allowing all domains | AWS.ApiGatewayV2Api.AccessControl.0630 |
+| Security Best Practices | ApiGatewayV2Api | Medium | Insecure Cross-Origin Resource Sharing Configuration allowing all domains | AWS.ApiGatewayV2Api.AccessControl.0630 |
 
 
 ### aws_efs_file_system
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | EFS | HIGH | Enable encryption of your EFS file systems in order to protect your data and metadata from breaches or unauthorized access and fulfill compliance requirements for data-at-rest encryption within your organization. | AWS.EFS.EncryptionandKeyManagement.High.0409 |
-| Encryption and Key Management | EFS | HIGH | Enable encryption of your EFS file systems in order to protect your data and metadata from breaches or unauthorized access and fulfill compliance requirements for data-at-rest encryption within your organization. | AWS.EFS.EncryptionandKeyManagement.High.0410 |
+| Data Protection | EFS | HIGH | Enable encryption of your EFS file systems in order to protect your data and metadata from breaches or unauthorized access and fulfill compliance requirements for data-at-rest encryption within your organization. | AWS.EFS.EncryptionandKeyManagement.High.0409 |
+| Data Protection | EFS | HIGH | Enable encryption of your EFS file systems in order to protect your data and metadata from breaches or unauthorized access and fulfill compliance requirements for data-at-rest encryption within your organization. | AWS.EFS.EncryptionandKeyManagement.High.0410 |
+
+
+### aws_lb_listener
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Infrastructure Security | ALL | MEDIUM | Ensure there is a listener configured on HTTPs or with a port 443 | AWS.ALL.IS.MEDIUM.0046 |
 
 
 ### aws_sqs_queue
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | SQS | HIGH | Identify any publicly accessible SQS queues available in your AWS account and update their permissions in order to protect against unauthorized users. | AWS.SQS.NetworkSecurity.High.0569 |
-| Network Security | SQS | HIGH | Ensure that your Amazon Simple Queue Service (SQS) queues are protecting the contents of their messages using Server-Side Encryption (SSE). The SQS service uses an AWS KMS Customer Master Key (CMK) to generate data keys required for the encryption/decryption process of SQS messages. There is no additional charge for using SQS Server-Side Encryption, however, there is a charge for using AWS KMS | AWS.SQS.NetworkSecurity.High.0570 |
+| Security Best Practices | SQS | HIGH | Identify any publicly accessible SQS queues available in your AWS account and update their permissions in order to protect against unauthorized users. | AWS.SQS.NetworkSecurity.High.0569 |
+| Security Best Practices | SQS | HIGH | Ensure that your Amazon Simple Queue Service (SQS) queues are protecting the contents of their messages using Server-Side Encryption (SSE). The SQS service uses an AWS KMS Customer Master Key (CMK) to generate data keys required for the encryption/decryption process of SQS messages. There is no additional charge for using SQS Server-Side Encryption, however, there is a charge for using AWS KMS | AWS.SQS.NetworkSecurity.High.0570 |
+
+
+### aws_docdb_cluster
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Data Protection | ADC | MEDIUM | Ensure DocDb is encrypted at rest | AWS.ADC.DP.MEDIUM.0022 |
+| Logging and Monitoring | ADC | MEDIUM | Ensure DocDb clusters have log exports enabled. | AWS.ADC.LM.MEDIUM.0069 |
+
+
+### aws_cloudwatch_log_group
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Logging and Monitoring | ACLG | MEDIUM | Ensure AWS Cloudwatch log group has retention policy set. | AWS.ACLG.LM.MEDIUM.0068 |
 
 
 ### aws_instance
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | json | MEDIUM | EC2 instances should disable IMDS or require IMDSv2 | AC-AWS-NS-IN-M-1172 |
-| Network Security | Instance | MEDIUM | Instance should be configured in vpc. AWS VPCs provides the controls to facilitate a formal process for approving and testing all network connections and changes to the firewall and router configurations. | AWS.Instance.NetworkSecurity.Medium.0506 |
+| Infrastructure Security | json | MEDIUM | EC2 instances should disable IMDS or require IMDSv2 as this can be related to the weaponization phase of kill chain | AC-AWS-NS-IN-M-1172 |
+| Identity and Access Management | json | HIGH | Ensure that instance launched follows the least privilege principle as this can be related to delivery-exploitation-Installation phases of kill  chain | AC-AW-IA-LC-H-0442 |
+| Logging and Monitoring | AI | HIGH | Ensure that detailed monitoring is enabled for EC2 instances. | AWS.AI.LM.HIGH.0070 |
+| Infrastructure Security | json | HIGH | Security group attached to launch configuration is wide open to internet and this can be related to reconnaissance phase | AC-AW-IS-LC-H-0443 |
+| Infrastructure Security | json | MEDIUM | Ensure that your AWS application is not deployed within the default Virtual Private Cloud in order to follow security best practices | AC-AW-IS-IN-M-0144 |
 
 
 ### aws_config
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Encryption & Key Management | Config | MEDIUM | Ensure AWS Config Rule is enabled for Encrypted Volumes | AWS.Config.Encryption&KeyManagement.Medium.0660 |
+| Data Protection | Config | MEDIUM | Ensure AWS Config Rule is enabled for Encrypted Volumes | AWS.Config.EncryptionandKeyManagement.Medium.0660 |
 
 
 ### aws_cloudformation_stack
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-|   | CloudFormation | MEDIUM | AWS CloudFormation Not In Use | AWS.CloudFormation.Medium.0599 |
-|   | CloudFormation | MEDIUM | AWS CloudFormation Stack Policy | AWS.CloudFormation.Medium.0604 |
-|   | CloudFormation | MEDIUM | Enable AWS CloudFormation Stack Termination Protection | AWS.CloudFormation.Medium.0605 |
-|   | CloudFormation | MEDIUM | Enable AWS CloudFormation Stack Notifications | AWS.CloudFormation.Medium.0603 |
+| Security Best Practices | CloudFormation | MEDIUM | AWS CloudFormation Not In Use | AWS.CloudFormation.Medium.0599 |
+| Security Best Practices | CloudFormation | MEDIUM | AWS CloudFormation Stack Policy | AWS.CloudFormation.Medium.0604 |
+| Security Best Practices | CloudFormation | MEDIUM | Enable AWS CloudFormation Stack Termination Protection | AWS.CloudFormation.Medium.0605 |
+| Security Best Practices | CloudFormation | MEDIUM | Enable AWS CloudFormation Stack Notifications | AWS.CloudFormation.Medium.0603 |
 
 
 ### aws_iam_user_policy
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Identity and Access Management | IamPolicy | HIGH | It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges. | AWS.IamPolicy.IAM.High.0392 |
-| Identity and Access Management | IamUser | HIGH | Ensure Hardware MFA device is enabled for the "root" account | AWS.IamUser.IAM.High.0387 |
-| Identity and Access Management | IamUser | HIGH | Ensure Virtual MFA device is enabled for the "root" account | AWS.IamUser.IAM.High.0388 |
-| Identity and Access Management | IamUser | HIGH | It is recommended that MFA be enabled for all accounts that have a console password. Enabling MFA provides increased security for console access as it requires the authenticating principal to possess a device that emits a time-sensitive key and have knowledge of a credential | AWS.IamUser.IAM.High.0389 |
+| Compliance Validation | IamUser | HIGH | Ensure Hardware MFA device is enabled for the "root" account | AWS.IamUser.IAM.High.0387 |
+| Identity and Access Management | json | HIGH | It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges. | AC-AW-IA-H-1190 |
+| Identity and Access Management | AIUP | MEDIUM | Ensure IAM policies are attached only to groups or roles | AWS.AIUP.IAM.MEDIUM.0049 |
+| Compliance Validation | IamUser | HIGH | Ensure Virtual MFA device is enabled for the "root" account | AWS.IamUser.IAM.High.0388 |
+| Compliance Validation | IamUser | HIGH | It is recommended that MFA be enabled for all accounts that have a console password. Enabling MFA provides increased security for console access as it requires the authenticating principal to possess a device that emits a time-sensitive key and have knowledge of a credential | AWS.IamUser.IAM.High.0389 |
 
 
 ### aws_ecs_task_definition
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | EcsCluster | HIGH | Like any other EC2 instance it is recommended to place ECS instance within a VPC. AWS VPCs provides the controls to facilitate a formal process for approving and testing all network connections and changes to the firewall and router configurations | AWS.EcsCluster.NetworkSecurity.High.0104 |
-| Data Security | LaunchConfiguration | HIGH | Sensitive Information Disclosure | AWS.LaunchConfiguration.DataSecurity.High.0101 |
+| Infrastructure Security | EcsCluster | HIGH | Like any other EC2 instance it is recommended to place ECS instance within a VPC. AWS VPCs provides the controls to facilitate a formal process for approving and testing all network connections and changes to the firewall and router configurations | AWS.EcsCluster.NetworkSecurity.High.0104 |
+| Infrastructure Security | AETD | MEDIUM | Ensure EFS volume used for ECS task defination has in transit encryption enabled | AWS.AETD.IS.MEDIUM.0043 |
+| Data Protection | LaunchConfiguration | HIGH | Sensitive Information Disclosure | AWS.LaunchConfiguration.DataSecurity.High.0101 |
 
 
 ### aws_ecr_repository_policy
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Data Security | ECR | HIGH | Identify any exposed Amazon ECR image repositories available within your AWS account and update their permissions in order to protect against unauthorized access. Amazon Elastic Container Registry (ECR) is a managed Docker registry service that makes it easy for DevOps teams to store, manage and deploy Docker container images. An ECR repository is a collection of Docker images available on AWS cloud. | AWS.ECR.DataSecurity.High.0579 |
+| Identity and Access Management | ECR | HIGH | Identify any exposed Amazon ECR image repositories available within your AWS account and update their permissions in order to protect against unauthorized access. Amazon Elastic Container Registry (ECR) is a managed Docker registry service that makes it easy for DevOps teams to store, manage and deploy Docker container images. An ECR repository is a collection of Docker images available on AWS cloud. | AWS.ECR.DataSecurity.High.0579 |
 
 
 ### aws_iam_policy
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Identity and Access Management | IamPolicy | HIGH | It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges. | AWS.IamPolicy.IAM.High.0392 |
+| Identity and Access Management | json | HIGH | It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges. | AC-AW-IA-H-1187 |
+
+
+### aws_dynamodb_table
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Resilience | DynamoDb | MEDIUM | Ensure Point In Time Recovery is enabled for DynamoDB Tables | AWS.DynamoDb.Logging.Medium.007 |
+| Data Protection | ADT | MEDIUM | Ensure DynamoDb is encrypted at rest | AWS.ADT.DP.MEDIUM.0025 |
 
 
 ### aws_apigatewayv2_stage
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Logging | ApiGatewayV2Stage | Low | AWS API Gateway V2 Stage is missing access logs | AWS.ApiGatewayV2Stage.Logging.0630 |
+| Logging and Monitoring | ApiGatewayV2Stage | Low | AWS API Gateway V2 Stage is missing access logs | AWS.ApiGatewayV2Stage.Logging.0630 |
 
 
 ### aws_ecr_repository
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Data Security | ECR | MEDIUM | Unscanned images may contain vulnerabilities | AWS.ECR.DataSecurity.High.0578 |
+| Data Protection | AER | MEDIUM | Ensure ECR repository is encrypted at rest | AWS.AER.DP.MEDIUM.0026 |
+| Configuration and Vulnerability Analysis | ECR | MEDIUM | Unscanned images may contain vulnerabilities | AWS.ECR.DataSecurity.High.0578 |
+| Identity and Access Management | AER | MEDIUM | Ensure ECR repository has policy attached. | AWS.AER.DP.MEDIUM.0058 |
 
 
 ### aws_cloudfront_distribution
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | CloudFront | HIGH | Secure ciphers are not used in CloudFront distribution | AWS.CloudFront.EncryptionandKeyManagement.High.0408 |
-| Network Security | CloudFront | LOW | Ensure that geo restriction is enabled for your Amazon CloudFront CDN distribution to whitelist or blacklist a country in order to allow or restrict users in specific locations from accessing web application content. | AWS.CloudFront.Network Security.Low.0568 |
-| Encryption and Key Management | CloudFront | HIGH | Use encrypted connection between CloudFront and origin server | AWS.CloudFront.EncryptionandKeyManagement.High.0407 |
-| Logging | CloudFront | MEDIUM | Ensure that your AWS Cloudfront distributions have the Logging feature enabled in order to track all viewer requests for the content delivered through the Content Delivery Network (CDN). | AWS.CloudFront.Logging.Medium.0567 |
+| Data Protection | CloudFront | HIGH | Secure ciphers are not used in CloudFront distribution | AWS.CloudFront.EncryptionandKeyManagement.High.0408 |
+| Infrastructure Security | json | LOW | Ensure that geo restriction is enabled for your Amazon CloudFront CDN distribution to whitelist or blacklist a country in order to allow or restrict users in specific locations from accessing web application content. | AC-AW-IS-CD-M-0026 |
+| Infrastructure Security | json | Medium | Ensure that cloud-front has web application firewall enabled | AC-AW-IS-CD-M-1186 |
+| Data Protection | CloudFront | HIGH | Use encrypted connection between CloudFront and origin server | AWS.CloudFront.EncryptionandKeyManagement.High.0407 |
+| Logging and Monitoring | CloudFront | MEDIUM | Ensure that your AWS Cloudfront distributions have the Logging feature enabled in order to track all viewer requests for the content delivered through the Content Delivery Network (CDN). | AWS.CloudFront.Logging.Medium.0567 |
 
 
 ### aws_cloudwatch
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Logging | CloudWatch | MEDIUM | App-Tier CloudWatch Log Group Retention Period | AWS.CloudWatch.Logging.Medium.0631 |
-| Encryption and Key Management | CloudWatch | HIGH | AWS CloudWatch log group is not encrypted with a KMS CMK | AWS.CloudWatch.EncryptionandKeyManagement.High.0632 |
+| Logging and Monitoring | CloudWatch | MEDIUM | App-Tier CloudWatch Log Group Retention Period | AWS.CloudWatch.Logging.Medium.0631 |
+| Data Protection | CloudWatch | HIGH | AWS CloudWatch log group is not encrypted with a KMS CMK | AWS.CloudWatch.EncryptionandKeyManagement.High.0632 |
 
 
 ### aws_ami_launch_permission
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | AMI | MEDIUM | Limit access to AWS AMIs | AWS.AMI.NS.Medium.1040 |
+| Infrastructure Security | AMI | MEDIUM | Limit access to AWS AMIs | AWS.AMI.NS.Medium.1040 |
 
 
 ### aws_launch_configuration
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | EcsCluster | HIGH | Ensure that AWS ECS clusters are encrypted. Data encryption at rest, prevents unauthorized users from accessing sensitive data on your AWS ECS clusters and associated cache storage systems. | AWS.EcsCluster.EncryptionandKeyManagement.High.0413 |
-| Data Security | LaunchConfiguration | HIGH | Avoid using base64 encoded private keys as part of config | AWS.LaunchConfiguration.DataSecurity.High.0102 |
-| Data Security | LaunchConfiguration | HIGH | Avoid using base64 encoded shell script as part of config | AWS.LaunchConfiguration.DataSecurity.High.0101 |
+| Data Protection | EcsCluster | HIGH | Ensure that AWS ECS clusters are encrypted. Data encryption at rest, prevents unauthorized users from accessing sensitive data on your AWS ECS clusters and associated cache storage systems. | AWS.EcsCluster.EncryptionandKeyManagement.High.0413 |
+| Identity and Access Management | json | HIGH | Ensure that launch configuration launched follows the least privilege principle | AC-AW-IA-LC-H-0441 |
+| Data Protection | LaunchConfiguration | HIGH | Avoid using base64 encoded private keys as part of config | AWS.LaunchConfiguration.DataSecurity.High.0102 |
+| Data Protection | LaunchConfiguration | HIGH | Avoid using base64 encoded shell script as part of config | AWS.LaunchConfiguration.DataSecurity.High.0101 |
+| Logging and Monitoring | json | Medium | It is important to enable cloudWatch monitoring incase monitoring the activity | AC-AW-LM-LC-M-0440 |
+| Configuration and Vulnerability Analysis | json | HIGH | Launch configuration uses IMDSv1 which vulnerable to SSRF | AC-AW-CA-LC-H-0439 |
+| Infrastructure Security | json | HIGH | Security group attached to launch configuration is wide open to internet  | AC-AW-IS-LC-H-0438 |
+
+
+### aws_athena_database
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Data Protection | ADB | MEDIUM | Ensure Athena Database is encrypted at rest | AWS.ADB.DP.MEDIUM.016 |
 
 
 ### aws_api_gateway_stage
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | API Gateway | MEDIUM | Enable SSL Client Certificate | AWS.API Gateway.Network Security.Medium.0565 |
-| Logging | API Gateway | MEDIUM | Ensure that AWS CloudWatch logs are enabled for all your APIs created with Amazon API Gateway service in order to track and analyze execution behavior at the API stage level. | AWS.API Gateway.Logging.Medium.0572 |
-| Logging | API Gateway | MEDIUM | Enable Active Tracing | AWS.API Gateway.Logging.Medium.0571 |
-| Logging | API Gateway | MEDIUM | Enable AWS CloudWatch Logs for APIs | AWS.API Gateway.Logging.Medium.0567 |
+| Infrastructure Security | API Gateway | MEDIUM | Enable SSL Client Certificate | AWS.APIGateway.NetworkSecurity.Medium.0565 |
+| Logging and Monitoring | API Gateway | MEDIUM | Ensure that AWS CloudWatch logs are enabled for all your APIs created with Amazon API Gateway service in order to track and analyze execution behavior at the API stage level. | AWS.APIGateway.Logging.Medium.0572 |
+| Logging and Monitoring | API Gateway | LOW | Ensure AWS API Gateway has active xray tracing enabled | AWS.APIGateway.Logging.Medium.0571 |
+| Logging and Monitoring | API Gateway | MEDIUM | Enable AWS CloudWatch Logs for APIs | AWS.APIGateway.Logging.Medium.0567 |
 
 
 ### aws_elasticsearch_domain
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | ElasticSearch | MEDIUM | Enable AWS ElasticSearch Encryption At Rest | AWS.ElasticSearch.EKM.Medium.0778 |
-| Encryption and Key Management | ElasticSearch | MEDIUM | ElasticSearch Domain Encrypted with KMS CMKs | AWS.ElasticSearch.EKM.Medium.0768 |
-| Logging | Elasticsearch | MEDIUM | Ensure that your AWS Elasticsearch clusters have enabled the support for publishing slow logs to AWS CloudWatch Logs. This feature enables you to publish slow logs from the indexing and search operations performed on your ES clusters and gain full insight into the performance of these operations. | AWS.Elasticsearch.Logging.Medium.0573 |
+| Data Protection | ElasticSearch | HIGH | Enable AWS ElasticSearch Encryption At Rest | AWS.ElasticSearch.EKM.Medium.0778 |
+| Infrastructure Security | ElasticSearch | MEDIUM | Ensure Elasticsearch domains being created are set to be encrypted node-to-node | AWS.ElasticSearch.IS.MEDIUM.0045 |
+| Data Protection | ElasticSearch | MEDIUM | ElasticSearch Domain Encrypted with KMS CMKs | AWS.ElasticSearch.EKM.Medium.0768 |
+| Compliance Validation | Elasticsearch | MEDIUM | Ensure that your AWS Elasticsearch clusters have enabled the support for publishing slow logs to AWS CloudWatch Logs. This feature enables you to publish slow logs from the indexing and search operations performed on your ES clusters and gain full insight into the performance of these operations. | AWS.Elasticsearch.Logging.Medium.0573 |
 
 
 ### aws_iam_user_login_profile
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Identity and Access Management | Iam | HIGH | Password policies are, in part, used to enforce password complexity requirements. IAM password policies can be used to ensure password are comprised of different character sets, have minimal length, rotation and history restrictions | AWS.Iam.IAM.High.0391 |
+| Compliance Validation | Iam | HIGH | Password policies are, in part, used to enforce password complexity requirements. IAM password policies can be used to ensure password are comprised of different character sets, have minimal length, rotation and history restrictions | AWS.Iam.IAM.High.0391 |
 
 
 ### aws_iam_group_policy
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Identity and Access Management | IamPolicy | HIGH | It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges. | AWS.IamPolicy.IAM.High.0392 |
+| Identity and Access Management | json | HIGH | It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges. | AC-AW-IA-H-0392 |
 
 
 ### aws_load_balancer_policy
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | ELB | HIGH | Using insecure ciphers for your ELB Predefined or Custom Security Policy, could make the SSL connection between the client and the load balancer vulnerable to exploits. TLS 1.0 was recommended to be disabled by PCI Council after June 30, 2016 | AWS.ELB.EncryptionandKeyManagement.High.0401 |
-| Encryption and Key Management | ELB | HIGH | Remove insecure ciphers for your ELB Predefined or Custom Security Policy, to reduce the risk of the SSL connection between the client and the load balancer being exploited. | AWS.ELB.EncryptionandKeyManagement.High.0403 |
+| Infrastructure Security | ELB | HIGH | Using insecure ciphers for your ELB Predefined or Custom Security Policy, could make the SSL connection between the client and the load balancer vulnerable to exploits. TLS 1.0 was recommended to be disabled by PCI Council after June 30, 2016 | AWS.ELB.EncryptionandKeyManagement.High.0401 |
+| Infrastructure Security | ELB | HIGH | Remove insecure ciphers for your ELB Predefined or Custom Security Policy, to reduce the risk of the SSL connection between the client and the load balancer being exploited. | AWS.ELB.EncryptionandKeyManagement.High.0403 |
 
 
 ### aws_s3_bucket
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| IAM | S3Bucket | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.S3Bucket.IAM.High.0377 |
-| Network Security | S3Bucket | HIGH | Ensure that there are not any static websites being hosted on buckets you aren't aware of | AWS.S3Bucket.NetworkSecurity.High.0417 |
-| IAM | S3Bucket | HIGH | Enabling S3 versioning will enable easy recovery from both unintended user actions, like deletes and overwrites | AWS.S3Bucket.IAM.High.0370 |
-| S3 | S3Bucket | HIGH | S3 bucket Access is allowed to all AWS Account Users. | AWS.S3Bucket.DS.High.1043 |
-| IAM | S3Bucket | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.S3Bucket.IAM.High.0379 |
-| Encryption and Key Management | S3Bucket | HIGH | Ensure that S3 Buckets have server side encryption at rest enabled with KMS key to protect sensitive data. | AWS.S3Bucket.EncryptionandKeyManagement.High.0405 |
-| IAM | S3Bucket | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.S3Bucket.IAM.High.0378 |
-| IAM | S3Bucket | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.S3Bucket.IAM.High.0381 |
+| Identity and Access Management | S3Bucket | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.S3Bucket.IAM.High.0377 |
+| Identity and Access Management | S3Bucket | HIGH | Ensure S3 buckets do not have, a both public ACL on the bucket and a public access block. | AWS.S3Bucket.IAM.HIGH.0065 |
+| Logging and Monitoring | S3Bucket | MEDIUM | Ensure S3 buckets have access logging enabled. | AWS.S3Bucket.LM.MEDIUM.0078 |
+| Infrastructure Security | S3Bucket | LOW | Ensure that there are not any static websites being hosted on buckets you aren't aware of | AWS.S3Bucket.NetworkSecurity.High.0417 |
+| Resilience | S3Bucket | HIGH | Enabling S3 versioning will enable easy recovery from both unintended user actions, like deletes and overwrites | AWS.S3Bucket.IAM.High.0370 |
+| Identity and Access Management | S3Bucket | HIGH | S3 bucket Access is allowed to all AWS Account Users. | AWS.S3Bucket.DS.High.1043 |
+| Identity and Access Management | S3Bucket | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.S3Bucket.IAM.High.0379 |
+| Data Protection | S3Bucket | HIGH | Ensure that S3 Buckets have server side encryption at rest enabled with KMS key to protect sensitive data. | AWS.S3Bucket.EncryptionandKeyManagement.High.0405 |
+| Identity and Access Management | S3Bucket | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.S3Bucket.IAM.High.0378 |
+| Identity and Access Management | S3Bucket | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.S3Bucket.IAM.High.0381 |
+
+
+### aws_eks_cluster
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Logging and Monitoring | AEC | MEDIUM | Ensure EKS clusters have control plane logging enabled. | AWS.AEC.LM.MEDIUM.0071 |
 
 
 ### aws_elb
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Ports Security | ELB | LOW | AWS ELB incoming traffic not encrypted | AWS.ELB.NetworkPortsSecurity.Low.0563 |
+| Logging and Monitoring | ELB | MEDIUM | Ensure AWS ELB has access logging enabled. | AWS.ELB.LM.MEDIUM.0072 |
+| Infrastructure Security | ELB | LOW | AWS ELB incoming traffic not encrypted | AWS.ELB.NetworkPortsSecurity.Low.0563 |
 
 
 ### aws_redshift_cluster
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | Redshift | HIGH | Ensure Redshift clusters are not publicly accessible to minimize security risks. | AWS.Redshift.NetworkSecurity.HIGH.0564 |
-| Logging | Redshift | MEDIUM | Ensure audit logging is enabled for Redshift clusters for security and troubleshooting purposes. | AWS.Redshift.Logging.Medium.0565 |
-| Encryption and Key Management | Redshift | HIGH | Use customer-managed KMS keys instead of AWS-managed keys, to have granular control over encrypting and encrypting data. Encrypt Redshift clusters with a Customer-managed KMS key. This is a recommended best practice. | AWS.Redshift.EncryptionandKeyManagement.High.0415 |
+| Infrastructure Security | Redshift | HIGH | Ensure Redshift clusters are not publicly accessible to minimize security risks. | AWS.Redshift.NetworkSecurity.HIGH.0564 |
+| Logging and Monitoring | Redshift | LOW | Ensure AWS Redshift cluster instances have logging enabled. | AWS.Redshift.Logging.Medium.0565 |
+| Data Protection | Redshift | MEDIUM | Use customer-managed KMS keys instead of AWS-managed keys, to have granular control over encrypting and encrypting data. Encrypt Redshift clusters with a Customer-managed KMS key. This is a recommended best practice. | AWS.Redshift.EncryptionandKeyManagement.High.0415 |
+
+
+### aws_elasticcache_replication_group
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Data Protection | AERG | MEDIUM | Ensure Elastic Cache Replication Group is encrypted at rest | AWS.AERG.DP.MEDIUM.0027 |
+| Data Protection | AERG | MEDIUM | Ensure Elastic Cache Replication Group is encrypted in transit | AWS.AERG.DP.MEDIUM.0044 |
 
 
 ### aws_kinesis_stream
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | Kinesis | HIGH | Kinesis Streams and metadata are not protected | AWS.Kinesis.EncryptionandKeyManagement.High.0412 |
+| Data Protection | Kinesis | HIGH | Ensure Kinesis Stream is encrypted | AWS.Kinesis.EncryptionandKeyManagement.High.0412 |
 
 
 ### aws_config_configuration_aggregator
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Logging | Config | HIGH | Ensure AWS Config is enabled in all regions | AWS.Config.Logging.HIGH.0590 |
+| Logging and Monitoring | Config | HIGH | Ensure AWS Config is enabled in all regions | AWS.Config.Logging.HIGH.0590 |
 
 
-### aws_organizations_policy
+### aws_s3_bucket_object
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| IAM | Organizations | MEDIUM | Ensure that All Features is enabled within your Amazon Organizations to achieve full control over the use of AWS services and actions across multiple AWS accounts using Service Control Policies (SCPs). | AWS.Organizations.IAM.MEDIUM.0590 |
+| Data Protection | ASBO | MEDIUM | Ensure S3 object is Encrypted | AWS.ASBO.DP.MEDIUM.0034 |
 
 
 ### aws_route53_query_log
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Logging | Route53 query logs | MEDIUM | Ensure CloudWatch logging is enabled for Route53 hosted zones. | AWS.Route53 query logs.Logging.Medium.0574 |
+| Logging and Monitoring | Route53 query logs | MEDIUM | Ensure CloudWatch logging is enabled for Route53 hosted zones. | AWS.Route53querylogs.Logging.Medium.0574 |
+
+
+### aws_secretsmanager_secret
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Data Protection | SecretsManagerSecret | MEDIUM | Ensure SecretsManager Secrets are Encrypted using KMS key | AWS.SecretsManagerSecret.DP.MEDIUM.0036 |
 
 
 ### aws_iam_access_key
@@ -299,18 +400,31 @@ description: >
 | Identity and Access Management | IamUser | MEDIUM | Ensure that there are no exposed Amazon IAM access keys in order to protect your AWS resources against unapproved access | AWS.IamUser.IAM.High.0391 |
 
 
+### aws_neptune_cluster
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Data Protection | ANC | MEDIUM | Ensure Neptune Cluster is Encrypted | AWS.ANC.DP.MEDIUM.0030 |
+| Logging and Monitoring | ANC | MEDIUM | Ensure AWS Neptune clusters have logging enabled. | AWS.ANC.LM.MEDIUM.0075 |
+
+
+### aws_dax_cluster
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Data Protection | ADC | MEDIUM | Ensure server-side encryption is enabled for AWS DAX Cluster | AWS.ADC.DP.MEDIUM.0021 |
+
+
 ### aws_guardduty_detector
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Logging | GuardDuty Enabled | MEDIUM | Ensure that Amazon GuardDuty service is currently enabled in all regions in order to protect your AWS environment and infrastructure (AWS accounts and resources, IAM credentials, guest operating systems, applications, etc) against security threats. AWS GuardDuty is a managed threat detection service that continuously monitors your VPC flow logs, AWS CloudTrail event logs and DNS logs for malicious or unauthorized behavior. The service monitors for activity such as unusual API calls, potentially compromised EC2 instances or potentially unauthorized deployments that indicate a possible AWS account compromise. AWS GuardDuty operates entirely on Amazon Web Services infrastructure and does not affect the performance or reliability of your applications. The service does not require any software agents, sensors or network appliances. | AWS.GuardDuty Enabled.Security.Medium.0575 |
+| Logging and Monitoring | GuardDuty Enabled | MEDIUM | Ensure that Amazon GuardDuty service is currently enabled in all regions in order to protect your AWS environment and infrastructure (AWS accounts and resources, IAM credentials, guest operating systems, applications, etc) against security threats. AWS GuardDuty is a managed threat detection service that continuously monitors your VPC flow logs, AWS CloudTrail event logs and DNS logs for malicious or unauthorized behavior. The service monitors for activity such as unusual API calls, potentially compromised EC2 instances or potentially unauthorized deployments that indicate a possible AWS account compromise. AWS GuardDuty operates entirely on Amazon Web Services infrastructure and does not affect the performance or reliability of your applications. The service does not require any software agents, sensors or network appliances. | AWS.GuardDutyEnabled.Security.Medium.0575 |
 
 
 ### aws_db_security_group
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | RDS | HIGH | RDS should not be defined with public interface. Firewall and router configurations should be used to restrict connections between untrusted networks and any system components in the cloud environment. | AWS.RDS.NetworkSecurity.High.0101 |
-| Network Security | RDS | HIGH | RDS should not be open to a large scope. Firewall and router configurations should be used to restrict connections between untrusted networks and any system components in the cloud environment. | AWS.RDS.NetworkSecurity.High.0103 |
-| Network Security | RDS | HIGH | RDS should not be open to a public scope. Firewall and router configurations should be used to restrict connections between untrusted networks and any system components in the cloud environment. | AWS.RDS.NetworkSecurity.High.0102 |
+| Infrastructure Security | RDS | HIGH | RDS should not be defined with public interface. Firewall and router configurations should be used to restrict connections between untrusted networks and any system components in the cloud environment. | AWS.RDS.NetworkSecurity.High.0101 |
+| Infrastructure Security | RDS | HIGH | RDS should not be open to a large scope. Firewall and router configurations should be used to restrict connections between untrusted networks and any system components in the cloud environment. | AWS.RDS.NetworkSecurity.High.0103 |
+| Infrastructure Security | RDS | HIGH | RDS should not be open to a public scope. Firewall and router configurations should be used to restrict connections between untrusted networks and any system components in the cloud environment. | AWS.RDS.NetworkSecurity.High.0102 |
 
 
 ### aws_s3_bucket_policy
@@ -327,96 +441,220 @@ description: >
 ### aws_ami
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Encryption & KeyManagement | EC2 | MEDIUM | Enable AWS AMI Encryption | AWS.EC2.Encryption&KeyManagement.Medium.0688 |
+| Infrastructure Security | EC2 | MEDIUM | Enable AWS AMI Encryption | AWS.EC2.EncryptionandKeyManagement.Medium.0688 |
 
 
 ### aws_elasticache_cluster
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Data Security | ElastiCache | HIGH | ElastiCache for Redis version is not compliant with AWS PCI DSS requirements | AWS.ElastiCache.DataSecurity.High.0425 |
-| Data Security | ElastiCache | HIGH | ElastiCache for Memcached is not in use in AWS PCI DSS environments | AWS.ElastiCache.DataSecurity.High.0424 |
-| High Availability | ElastiCache | MEDIUM | AWS ElastiCache Multi-AZ | AWS.ElastiCache.HighAvailability.Medium.0757 |
+| Compliance Validation | ElastiCache | HIGH | ElastiCache for Redis version is not compliant with AWS PCI DSS requirements | AWS.ElastiCache.DataSecurity.High.0425 |
+| Compliance Validation | ElastiCache | HIGH | ElastiCache for Memcached is not in use in AWS PCI DSS environments | AWS.ElastiCache.DataSecurity.High.0424 |
+| Resilience | ElastiCache | MEDIUM | AWS ElastiCache Multi-AZ | AWS.ElastiCache.HighAvailability.Medium.0757 |
 
 
 ### aws_kinesis_firehose_delivery_stream
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | Kinesis | HIGH | AWS Kinesis Server data at rest has server side encryption (SSE) | AWS.Kinesis.EncryptionandKeyManagement.High.0411 |
+| Data Protection | Kinesis | HIGH | AWS Kinesis Server data at rest has server side encryption (SSE) | AWS.Kinesis.EncryptionandKeyManagement.High.0411 |
 
 
 ### aws_rds_cluster
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | RDS | HIGH | Encrypt Amazon RDS instances and snapshots at rest, by enabling the encryption option for your Amazon RDS DB instance | AWS.RDS.EncryptionandKeyManagement.High.0414 |
+| Resilience | RDS | MEDIUM | Ensure backup retention period is set for rds cluster | AWS.RDS.RE.MEDIUM.0013 |
+| Data Protection | RDS | HIGH | Encrypt Amazon RDS instances and snapshots at rest, by enabling the encryption option for your Amazon RDS DB instance | AWS.RDS.EncryptionandKeyManagement.High.0414 |
 
 
 ### aws_cloudtrail
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Logging | CloudTrail | HIGH | Cloud Trail Log Not Enabled | AWS.CloudTrail.Logging.High.0399 |
-| Logging | CloudTrail | MEDIUM | Cloud Trail Multi Region not enabled | AWS.CloudTrail.Logging.Medium.0460 |
-| Logging | CloudTrail | MEDIUM | Ensure appropriate subscribers to each SNS topic | AWS.CloudTrail.Logging.Low.0559 |
+| Logging and Monitoring | CloudTrail | HIGH | Ensure CloudTrail logs are encrypted using KMS | AWS.CloudTrail.Logging.High.0399 |
+| Logging and Monitoring | CloudTrail | MEDIUM | Cloud Trail Multi Region not enabled | AWS.CloudTrail.Logging.Medium.004 |
+| Security Best Practices | CloudTrail | MEDIUM | Ensure that EC2 is EBS optimized | AWS.CloudTrail.Logging.Medium.008 |
+| Security Best Practices | CloudTrail | LOW | ECR should have an image tag be immutable | AWS.CloudTrail.Logging.Low.009 |
+| Logging and Monitoring | CloudTrail | MEDIUM | Cloud Trail Multi Region not enabled | AWS.CloudTrail.Logging.Medium.0460 |
+| Logging and Monitoring | CloudTrail | MEDIUM | Ensure CloudTrail has log file validation enabled. | AWS.CloudTrail.LM.MEDIUM.0087 |
+| Logging and Monitoring | CloudTrail | MEDIUM | Ensure appropriate subscribers to each SNS topic | AWS.CloudTrail.Logging.Low.0559 |
+| Logging and Monitoring | Config | Medium | Ensure AWS Config is enabled in all regions | AWS.Config.Logging.Medium.0590 |
+
+
+### aws_sagemaker_notebook_instance
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Data Protection | ASNI | MEDIUM | Ensure SageMaker Instance is Encrypted | AWS.ASNI.DP.MEDIUM.0035 |
 
 
 ### aws_lambda_function
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Logging | LambdaFunction | Low | Lambda function doesn't not include a VPC configuration. | AWS.LambdaFunction.Logging.0472 |
-| Logging | LambdaFunction | LOW | Lambda tracing is not enabled. | AWS.LambdaFunction.Logging.0470 |
-| Encryption and Key Management | LambdaFunction | High | Lambda does not use KMS CMK key to protect environment variables. | AWS.LambdaFunction.EncryptionandKeyManagement.0471 |
+| Logging and Monitoring | LambdaFunction | MEDIUM | Ensure AWS Lambda function has policy attached. | AWS.LambdaFunction.LM.MEIDUM.0063 |
+| Infrastructure Security | LambdaFunction | Low | Lambda function doesn't not include a VPC configuration. | AWS.LambdaFunction.Logging.0472 |
+| Logging and Monitoring | LambdaFunction | LOW | Lambda tracing is not enabled. | AWS.LambdaFunction.Logging.0470 |
+| Data Protection | LambdaFunction | High | Lambda does not use KMS CMK key to protect environment variables. | AWS.LambdaFunction.EncryptionandKeyManagement.0471 |
+| Logging and Monitoring | LambdaFunction | LOW | Lambda tracing is not enabled. | AWS.LambdaFunction.Logging.0470 |
 
 
 ### aws_kms_key
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Logging | KMS | HIGH | Ensure rotation for customer created CMKs is enabled | AWS.KMS.Logging.High.0400 |
-| Network Security | KMS | HIGH | Identify any publicly accessible AWS Key Management Service master keys and update their access policy in order to stop any unsigned requests made to these resources. | AWS.KMS.NetworkSecurity.High.0566 |
+| Identity and Access Management | AKK | HIGH | Ensure IAM policies do not have 'Principal' element missing from the policy statement. | AWS.AKK.IAM.HIGH.0012 |
+| Identity and Access Management | KMS | HIGH | Identify any publicly accessible AWS Key Management Service master keys and update their access policy in order to stop any unsigned requests made to these resources. | AWS.KMS.NetworkSecurity.High.0566 |
+| Data Protection | AKK | HIGH | Ensure rotation for customer created CMKs is enabled | AWS.AKK.DP.HIGH.0012 |
+| Identity and Access Management | AKK | HIGH | Ensure KMS key policy does not have wildcard policies attached. | AWS.AKK.IAM.HIGH.0082 |
 
 
 ### aws_security_group
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Ports Security | ALB | MEDIUM | 'MSSQL Debugger' (TCP:135) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0236 |
-| Network Ports Security | ALB | MEDIUM | 'Cassandra OpsCenter agent port' (TCP:61621) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0220 |
-| Network Ports Security | SecurityGroup | HIGH | remote desktop port open to internet | AWS.SecurityGroup.NetworkPortsSecurity.Low.0562 |
-| Network Ports Security | ALB | MEDIUM | 'Memcached SSL' (TCP:11214) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0240 |
-| Network Ports Security | ALB | MEDIUM | 'NetBIOS Datagram Service' (TCP:138) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0256 |
-| Network Ports Security | ALB | MEDIUM | 'SNMP' (UDP:161) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0276 |
-| Network Ports Security | ALB | MEDIUM | 'NetBIOS Session Service' (TCP:139) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0260 |
-| Network Ports Security | ALB | MEDIUM | 'LDAP SSL ' (TCP:636) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0230 |
-| Network Ports Security | ALB | MEDIUM | 'Known internal web port' (TCP:8000) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0226 |
-| Network Ports Security | ALB | MEDIUM | 'Postgres SQL' (UDP:5432) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0270 |
-| Network Ports Security | SecurityGroup | HIGH | It is recommended that no security group allows unrestricted ingress access | AWS.SecurityGroup.NPS.High.1045 |
-| Network Ports Security | ALB | MEDIUM | 'Oracle DB SSL' (UDP:2484) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0266 |
-| Network Ports Security | SecurityGroup | HIGH | A VPC comes with a default security group whose initial settings deny all inbound traffic, allow all outbound traffic, and allow all traffic between instances assigned to the security group. If you don't specify a security group when you launch an instance, the instance is automatically assigned to this default security group. Security groups provide stateful filtering of ingress/egress network traffic to AWS resources. It is recommended that the default security group restrict all traffic. Configuring the default security group to restrict all traffic will encourage least privilege security group development and mindful placement of AWS resource into security groups which will in-turn reduce the exposure of those resources. | AWS.SecurityGroup.NetworkSecurity.High.0097 |
-| Network Ports Security | ALB | MEDIUM | 'Memcached SSL' (UDP:11215) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0246 |
-| Network Ports Security | ALB | MEDIUM | 'SaltStack Master' (TCP:4505) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0196 |
-| Network Ports Security | ALB | MEDIUM | 'MySQL' (TCP:3306) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0250 |
-| Network Ports Security | ALB | MEDIUM | 'Known internal web port' (TCP:8080) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0228 |
-| Network Ports Security | SecurityGroup | HIGH |  It is recommended that no security group allows unrestricted ingress access | AWS.SecurityGroup.NetworkSecurity.High.0094 |
-| Network Ports Security | ALB | MEDIUM | 'Hadoop Name Node' (TCP:9000) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0224 |
-| Network Ports Security | SecurityGroup | HIGH | Unknown Port is exposed to the entire internet | AWS.SecurityGroup.NPS.High.1046 |
-| Network Ports Security | ALB | MEDIUM | 'MSSQL Admin' (TCP:1434) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0232 |
-| Network Ports Security | ALB | MEDIUM | 'Mongo Web Portal' (TCP:27018) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0248 |
-| Network Ports Security | ALB | MEDIUM | 'Oracle DB SSL' (TCP:2484) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0264 |
-| Network Ports Security | ALB | MEDIUM | 'Prevalent known internal port' (TCP:3000) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0272 |
-| Network Ports Security | ALB | MEDIUM | 'NetBIOS Name Service' (TCP:137) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0252 |
-| Network Ports Security | ALB | HIGH | 'SSH' (TCP:22) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0194 |
-| Network Ports Security | ALB | MEDIUM | 'Memcached SSL' (UDP:11214) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0244 |
-| Network Ports Security | ALB | MEDIUM | 'Postgres SQL' (TCP:5432) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0268 |
-| Network Ports Security | ALB | MEDIUM | 'Cassandra' (TCP:7001) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0222 |
-| Network Ports Security | ALB | MEDIUM | 'MSSQL Browser Service' (UDP:1434) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0234 |
-| Network Ports Security | ALB | MEDIUM | 'CIFS / SMB' (TCP:3020) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0218 |
-| Network Ports Security | ALB | MEDIUM | 'SQL Server Analysis Services' (TCP:2383) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0280 |
-| Network Ports Security | ALB | MEDIUM | 'MSSQL Server' (TCP:1433) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0238 |
-| Network Ports Security | SecurityGroup | HIGH | ssh port open to internet | AWS.SecurityGroup.NetworkPortsSecurity.Low.0560 |
-| Network Ports Security | ALB | MEDIUM | 'NetBIOS Name Service' (UDP:137) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0254 |
-| Network Ports Security | SecurityGroup | HIGH | http port open to internet | AWS.SecurityGroup.NetworkPortsSecurity.Low.0561 |
-| Network Ports Security | ALB | MEDIUM | 'Memcached SSL' (TCP:11215) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0242 |
-| Network Ports Security | ALB | MEDIUM | 'SQL Server Analysis Service browser' (TCP:2382) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0278 |
-| Network Ports Security | ALB | MEDIUM | 'NetBIOS Datagram Service' (UDP:138) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0258 |
-| Network Ports Security | ALB | MEDIUM | 'NetBIOS Session Service' (UDP:139) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0262 |
-| Network Ports Security | ALB | MEDIUM | 'Puppet Master' (TCP:8140) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0274 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (UDP,11214) is not accessible by a public CIDR block range | AC_AWS_0292 |
+| Infrastructure Security | json | LOW | Ensure Cassandra' (TCP,7001) is not exposed to private hosts more than 32 | AC_AWS_0338 |
+| Infrastructure Security | json | MEDIUM | Ensure Known internal web port (TCP,8080) is not accessible by a CIDR block range | AC_AWS_0284 |
+| Infrastructure Security | json | MEDIUM | Ensure Oracle DB SSL (TCP,2484) is not accessible by a public CIDR block range | AC_AWS_0302 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - MSSQL Server (TCP,1433) | AC_AWS_0247 |
+| Infrastructure Security | json | LOW | Ensure SNMP' (UDP,161) is not exposed to private hosts more than 32 | AC_AWS_0355 |
+| Infrastructure Security | json | LOW | Ensure NetBIOSNameService' (TCP,137) is not exposed to private hosts more than 32 | AC_AWS_0343 |
+| Infrastructure Security | json | HIGH | Ensure SMTP (TCP,25) is not accessible by a public CIDR block range | AC_AWS_0314 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Memcached SSL (UDP,11215) | AC_AWS_0251 |
+| Infrastructure Security | json | LOW | Ensure Elasticsearch' (TCP,9300) is not exposed to private hosts more than 32 | AC_AWS_0363 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Telnet (TCP,23) | AC_AWS_0271 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports MemcachedSSL (UDP,11214) is not exposed to  private hosts more than 32 | AC_AWS_0334 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - SQL Server Analysis Service browser (TCP,2382) | AC_AWS_0267 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Debugger (TCP,135) is not accessible by a public CIDR block range | AC_AWS_0288 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports https (TCP,443) is not exposed to private hosts more than 32 | AC_AWS_0322 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - remote desktop port (TCP,3389) | AC_AWS_0230 |
+| Infrastructure Security | json | LOW | Ensure Telnet' (TCP,23) is not exposed to private hosts more than 32 | AC_AWS_0359 |
+| Infrastructure Security | json | HIGH | Ensure Elasticsearch (TCP,9300) is not accessible by a public CIDR block range | AC_AWS_0318 |
+| Infrastructure Security | json | LOW | Ensure SSH (TCP,22) is not accessible by a public CIDR block range | AC_AWS_0319 |
+| Infrastructure Security | json | LOW | Ensure OracleDatabaseServer' (TCP,521) is not exposed to private hosts more than 32 | AC_AWS_0358 |
+| Infrastructure Security | json | HIGH | Ensure no security groups allow ingress from 0.0.0.0/0 to ALL ports and protocols | AC_AWS_0231 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - SNMP (UDP,161) | AC_AWS_0266 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Server (TCP,1433) is not accessible by a public CIDR block range | AC_AWS_0289 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports remote desktop port (TCP,3389) is not exposed to private hosts more than 32 | AC_AWS_0323 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Oracle Database Server (TCP,1521) | AC_AWS_0270 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports MemcachedSSL (UDP,11215) is not exposed to  private hosts more than 32 | AC_AWS_0335 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - (SSH,22) | AC_AWS_0227 |
+| Infrastructure Security | json | LOW | Ensure MongoDB' (TCP,27017) is not exposed to private hosts more than 32 | AC_AWS_0362 |
+| Infrastructure Security | json | HIGH | Ensure CIFS for file/printer (TCP,445) is not accessible by a public CIDR block range | AC_AWS_0315 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Memcached SSL (UDP,11214) | AC_AWS_0250 |
+| Infrastructure Security | json | LOW | Ensure MongoWebPortal' (TCP,27018) is not exposed to private hosts more than 32 | AC_AWS_0342 |
+| Infrastructure Security | json | LOW | Ensure PuppetMaster' (TCP,8140) is not exposed to private hosts more than 32 | AC_AWS_0354 |
+| Infrastructure Security | json | MEDIUM | Ensure Oracle DB SSL (UDP,2484) is not accessible by a public CIDR block range | AC_AWS_0303 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - MSSQL Debugger (TCP,135) | AC_AWS_0246 |
+| Infrastructure Security | json | MEDIUM | Ensure LDAP SSL (TCP,636) is not accessible by a public CIDR block range | AC_AWS_0285 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (UDP,11215) is not accessible by a public CIDR block range | AC_AWS_0293 |
+| Infrastructure Security | json | LOW | Ensure HadoopNameNode' (TCP,9000) is not exposed to private hosts more than 32 | AC_AWS_0339 |
+| Infrastructure Security | json | MEDIUM | Ensure SaltStack Master (TCP,4505) is not accessible by a public CIDR block range | AC_AWS_0277 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports MemcachedSSL (TCP,11214) is not exposed to private hosts more than 32 | AC_AWS_0332 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBios Datagram Service (TCP,138) is not accessible by a public CIDR block range | AC_AWS_0298 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Oracle DB SSL (UDP,2484) | AC_AWS_0261 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports Elasticsearch (TCP,9200) is not exposed to  private hosts more than 32 | AC_AWS_0324 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - SaltStack Master (TCP,4506) | AC_AWS_0236 |
+| Infrastructure Security | json | MEDIUM | Ensure SNMP (UDP,161) is not accessible by a public CIDR block range | AC_AWS_0308 |
+| Infrastructure Security | json | LOW | Ensure OracleDBSSL' (TCP,2484) is not exposed to private hosts more than 32 | AC_AWS_0349 |
+| Infrastructure Security | json | MEDIUM | Ensure Mongo Web Portal (TCP,27018) is not accessible by a public CIDR block range | AC_AWS_0294 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports MSSQLAdmin (TCP,1434) is not exposed to private hosts more than 32 | AC_AWS_0328 |
+| Infrastructure Security | json | MEDIUM | Ensure Hadoop Name Node (TCP,9000) is not accessible by a public CIDR block range | AC_AWS_0282 |
+| Infrastructure Security | json | MEDIUM | Ensure Postgres SQL (TCP,5432) is not accessible by a public CIDR block range | AC_AWS_0304 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Known internal web port (TCP,8000) | AC_AWS_0241 |
+| Infrastructure Security | json | LOW | Ensure Prevalentknowninternalport' (TCP,3000) is not exposed to private hosts more than 32 | AC_AWS_0353 |
+| Infrastructure Security | json | LOW | Ensure NetBIOSNameService' (UDP,137) is not exposed to private hosts more than 32 | AC_AWS_0345 |
+| Infrastructure Security | json | HIGH | Ensure Oracle Database Server (TCP,1521) is not accessible by a public CIDR block range | AC_AWS_0312 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - NetBIOS Datagram Service (UDP,138) | AC_AWS_0257 |
+| Infrastructure Security | json | HIGH | Ensure Telnet (TCP,23) is not accessible by a public CIDR block range | AC_AWS_0313 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - NetBIOS Datagram Service (TCP,138) | AC_AWS_0256 |
+| Infrastructure Security | json | LOW | Ensure NetBIOSNameService' (UDP,137) is not exposed to private hosts more than 32 | AC_AWS_0344 |
+| Infrastructure Security | json | LOW | Ensure PostgresSQL' (UDP,5432) is not exposed to private hosts more than 32 | AC_AWS_0352 |
+| Infrastructure Security | json | MEDIUM | Ensure Postgres SQL (UDP,5432) is not accessible by a CIDR block range | AC_AWS_0305 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Hadoop Name Node (TCP,9000) | AC_AWS_0240 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports MSSQLBrowserService (UDP,1434) is not exposed to private hosts more than 32 | AC_AWS_0329 |
+| Infrastructure Security | json | MEDIUM | Ensure Known internal web port (TCP,8000) is not accessible by a public CIDR block range | AC_AWS_0283 |
+| Infrastructure Security | json | MEDIUM | Ensure MySQL (TCP,3306) is not accessible by a public CIDR block range | AC_AWS_0295 |
+| Infrastructure Security | json | LOW | Ensure NetBIOSSessionService' (UDP,139) is not exposed to private hosts more than 32 | AC_AWS_0348 |
+| Infrastructure Security | json | MEDIUM | Ensure SQL Server Analysis Service browser (TCP,2382) is not accessible by a public CIDR block range | AC_AWS_0309 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - CIFS / SMB (TCP,3020) | AC_AWS_0237 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Oracle DB SSL (TCP,2484) | AC_AWS_0260 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports SaltStackMaster (TCP,4506) is not exposed to private hosts more than 32 | AC_AWS_0325 |
+| Infrastructure Security | json | HIGH | Ensure Unknown Port is not exposed to the entire internet | AC_AWS_0276 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports MemcachedSSL (TCP,11215) is not exposed to private hosts more than 32 | AC_AWS_0333 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBios Datagram Service (UDP,138) is not accessible by a public CIDR block range | AC_AWS_0299 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - NetBIOS Session Service (UDP,139) | AC_AWS_0259 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Elasticsearch (TCP,9200) | AC_AWS_0234 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports CassandraOpsCenteragent (TCP,61621) is not exposed to private hosts more than 32 | AC_AWS_0326 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Postgres SQL (UDP,5432) | AC_AWS_0263 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports MSSQLDebugger (TCP,135) is not exposed to private hosts more than 32 | AC_AWS_0330 |
+| Infrastructure Security | json | HIGH | Ensure no security groups is wide open to public, that is, allows traffic from 0.0.0.0/0 to ALL ports and protocols | AC_AWS_0275 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - NetBIOS Name Service (UDP,137) | AC_AWS_0255 |
+| Infrastructure Security | json | MEDIUM | Ensure SQL Server Analysis Services (TCP,2383) is not accessible by a public CIDR block range | AC_AWS_0310 |
+| Infrastructure Security | json | LOW | Ensure NetBIOSSessionService' (TCP,139) is not exposed to private hosts more than 32 | AC_AWS_0347 |
+| Infrastructure Security | json | LOW | Ensure PostgresSQL' (TCP,5432) is not exposed to private hosts more than 32 | AC_AWS_0351 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - LDAP SSL (TCP,636) | AC_AWS_0243 |
+| Infrastructure Security | json | MEDIUM | Ensure Prevalent known internal port (TCP,3000) is not accessible by a public CIDR block range | AC_AWS_0306 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Cassandra OpsCenter agent (TCP,61621) | AC_AWS_0238 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra OpsCenter agent port (TCP,61621) is not accessible by a public CIDR block range | AC_AWS_0280 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBIOS Name Service (TCP,137) is not accessible by a public CIDR block range | AC_AWS_0296 |
+| Infrastructure Security | json | MEDIUM | Ensure CIFS / SMB (TCP,3020) is not accessible by a public CIDR block range | AC_AWS_0279 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBIOS Name Service (UDP,137) is not accessible by a public CIDR block range | AC_AWS_0297 |
+| Infrastructure Security | json | MEDIUM | Ensure SaltStack Master (TCP,4506) is not accessible by a public CIDR block range | AC_AWS_0278 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra (TCP,7001) is not accessible by a public CIDR block range | AC_AWS_0281 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Cassandra (TCP,7001) | AC_AWS_0239 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Known internal web port (TCP,8080) | AC_AWS_0242 |
+| Infrastructure Security | json | MEDIUM | Ensure Puppet Master (TCP:8140) is not accessible by a public CIDR block range | AC_AWS_0307 |
+| Infrastructure Security | json | LOW | Ensure OracleDBSSL' (UDP,2484) is not exposed to private hosts more than 32 | AC_AWS_0350 |
+| Infrastructure Security | json | LOW | Ensure NetBIOSDatagramService' (UDP,138) is not exposed to private hosts more than 32 | AC_AWS_0346 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - NetBIOS Name Service (TCP,137) | AC_AWS_0254 |
+| Infrastructure Security | json | MEDIUM | Ensure SaltStack Master (TCP,4505) is not accessible by a public CIDR block range | AC_AWS_0311 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports MSSQLServer (TCP,1433) is not exposed to private hosts more than 32 | AC_AWS_0331 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - MongoDB (TCP,27017) | AC_AWS_0274 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports Knowninternalwebport (TCP,8080) is not exposed to private hosts more than 32 | AC_AWS_0327 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Postgres SQL (TCP,5432) | AC_AWS_0262 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Elasticsearch (TCP,9300) | AC_AWS_0235 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - NetBIOS Session Service (TCP,139) | AC_AWS_0258 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - MySQL (TCP,3306) | AC_AWS_0253 |
+| Infrastructure Security | json | HIGH | Ensure MongoDB (TCP,27017) is not accessible by a public CIDR block range | AC_AWS_0316 |
+| Infrastructure Security | json | LOW | Ensure LDAPSSL' (TCP,636) is not exposed to private hosts more than 32 | AC_AWS_0341 |
+| Infrastructure Security | json | LOW | Ensure SQLServerAnalysisServices' (TCP,2383) is not exposed to private hosts more than 32 | AC_AWS_0357 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - MSSQL Browser Service (UDP,1434) | AC_AWS_0245 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBios Session Service (TCP,139) is not accessible by a CIDR block range | AC_AWS_0300 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Admin (TCP,1434) is not accessible by a public CIDR block range | AC_AWS_0286 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - SaltStack Master (TCP,4505) | AC_AWS_0269 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (TCP,11214) is not accessible by a public CIDR block range | AC_AWS_0290 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - (HTTP,80) | AC_AWS_0228 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Memcached SSL (TCP,11215) | AC_AWS_0249 |
+| Infrastructure Security | json | HIGH | Ensure no default security groups are used as they allow ingress from 0.0.0.0/0 to ALL ports and protocols | AC_AWS_0232 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports SSH (TCP,22) is not exposed to private hosts more than 32 | AC_AWS_0320 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Puppet Master (TCP,8140) | AC_AWS_0265 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports MySQL (TCP,3306) is not exposed to private hosts more than 32 | AC_AWS_0336 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - CIFS for file/printer (TCP,445) | AC_AWS_0273 |
+| Infrastructure Security | json | LOW | Ensure CIFSforfile/printer' (TCP,445) is not exposed to private hosts more than 32 | AC_AWS_0361 |
+| Infrastructure Security | json | LOW | Ensure SMTP' (TCP,25) is not exposed to private hosts more than 32 | AC_AWS_0360 |
+| Infrastructure Security | json | LOW | Ensure CIFS/SMB' (TCP,3020) is not exposed to private hosts more than 32 | AC_AWS_0337 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - SMTP (TCP,25) | AC_AWS_0272 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports http (TCP,80) is not exposed to private hosts more than 32 | AC_AWS_0321 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Prevalent known internal port (TCP,3000) | AC_AWS_0264 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - SaltStack Master (TCP,4505) | AC_AWS_0233 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Memcached SSL (TCP,11214) | AC_AWS_0248 |
+| Infrastructure Security | json | LOW | Security Groups - Unrestricted Specific Ports - (HTTPS,443) | AC_AWS_0229 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (TCP,11215) is not accessible by a public CIDR block range | AC_AWS_0291 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Browser Service (UDP,1434) is not accessible by a public CIDR block range | AC_AWS_0287 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - SQL Server Analysis Services (TCP,2383) | AC_AWS_0268 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - MSSQL Admin (TCP,1434) | AC_AWS_0244 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBios Session Service (UDP,139) is not accessible by a CIDR block range | AC_AWS_0301 |
+| Infrastructure Security | json | LOW | Ensure SQLServerAnalysisServicebrowser' (TCP,2382) is not exposed to private hosts more than 32 | AC_AWS_0356 |
+| Infrastructure Security | json | LOW | Ensure Knowninternalwebport' (TCP,8000) not exposed to private hosts more than 32 | AC_AWS_0340 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Mongo Web Portal (TCP,27018) | AC_AWS_0252 |
+| Infrastructure Security | json | HIGH | Ensure Elasticsearch (TCP,9200) is not accessible by a public CIDR block range | AC_AWS_0317 |
+
+
+### aws_api_gateway_method
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Infrastructure Security | APGM | LOW | Ensure there is no open access to back-end resources through API | AWS.APGM.IS.LOW.0056 |
+
+
+### aws_efs_file_system_policy
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Identity and Access Management | AEFSP | HIGH | Ensure EFS file system does not use insecure wildcard policies. | AWS.AEFSP.IAM.HIGH.0059 |
 
 
 ### aws_ecs_service
@@ -425,3 +663,13 @@ description: >
 | Identity and Access Management | ECS | HIGH | Ensure there are no ECS services Admin roles | AWS.ECS.High.0436 |
 
 
+### aws_globalaccelerator_accelerator
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Logging and Monitoring | AGA | LOW | Ensure Global Accelerator accelerator has flow logs enabled. | AWS.AGA.LM.LOW.0073 |
+
+
+### aws_api_gateway_rest_api_policy
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Identity and Access Management | APGRAP | HIGH | Ensure use of API Gateway endpoint policy, and no action wildcards are being used. | AWS.APGRAP.IAM.HIGH.0064 |

--- a/content/en/docs/Policies/azure.md
+++ b/content/en/docs/Policies/azure.md
@@ -3,14 +3,8 @@ title: "Azure Policies"
 linkTitle: "Azure Policies"
 weight: 30
 description: >
-      
+
 ---
-
-
-### azurerm_virtual_machine
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | HIGH | Ensure that at least one Network Security Group is attached to all VMs and subnets that are public | accurics.azure.NS.18 |
 
 
 ### azurerm_storage_container
@@ -22,371 +16,289 @@ description: >
 ### azurerm_mysql_server
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | HIGH | Ensure 'Enforce SSL connection' is set to 'ENABLED' for MySQL Database Server. | accurics.azure.NS.361 |
+| Infrastructure Security | azure | HIGH | Ensure 'Enforce SSL connection' is set to 'ENABLED' for MySQL Database Server. | accurics.azure.NS.361 |
 
 
 ### azurerm_sql_firewall_rule
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | MEDIUM | Restrict Azure SQL Server accessibility to a minimal address range | accurics.azure.NS.169 |
-| Network Security | azure | HIGH | Ensure entire Azure infrastructure doesn't have access to Azure SQL ServerEnsure entire Azure infrastructure doesn't have access to Azure SQL Server | accurics.azure.NS.5 |
-| Network Security | azure | HIGH | Ensure that no SQL Server allows ingress from 0.0.0.0/0 (ANY IP) | accurics.azure.NS.21 |
+| Infrastructure Security | azure | MEDIUM | Restrict Azure SQL Server accessibility to a minimal address range | accurics.azure.NS.169 |
+| Infrastructure Security | azure | HIGH | Ensure entire Azure infrastructure doesn't have access to Azure SQL ServerEnsure entire Azure infrastructure doesn't have access to Azure SQL Server | accurics.azure.NS.5 |
+| Infrastructure Security | azure | MEDIUM | Ensure that no SQL Server allows ingress from 0.0.0.0/0 (ANY IP) | accurics.azure.NS.21 |
 
 
 ### azurerm_key_vault
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | azure | MEDIUM | Ensure the key vault is recoverable - enable "Soft Delete" setting for a Key Vault | accurics.azure.EKM.164 |
-| Encryption and Key Management | azure | HIGH | Ensure that logging for Azure KeyVault is 'Enabled' | accurics.azure.EKM.20 |
+| Data Protection | azure | MEDIUM | Ensure the key vault is recoverable - enable "Soft Delete" setting for a Key Vault | accurics.azure.EKM.164 |
+| Logging and Monitoring | azure | HIGH | Ensure that logging for Azure KeyVault is 'Enabled' | accurics.azure.EKM.20 |
 
 
 ### azurerm_resource_group
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | LOW | Ensure that Azure Resource Group has resource lock enabled | accurics.azure.NS.272 |
+| Identity and Access Management | azure | LOW | Ensure that Azure Resource Group has resource lock enabled | accurics.azure.NS.272 |
 
 
 ### azurerm_storage_account_network_rules
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | MEDIUM | Ensure default network access rule for Storage Accounts is set to deny. | accurics.azure.NS.370 |
+| Infrastructure Security | azure | MEDIUM | Ensure default network access rule for Storage Accounts is set to deny. | accurics.azure.NS.370 |
 
 
 ### azurerm_storage_account
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | HIGH | Ensure 'Trusted Microsoft Services' is enabled for Storage Account access | accurics.azure.NS.2 |
-| Network Security | azure | HIGH | Ensure default network access rule for Storage Accounts is not open to public | accurics.azure.NS.4 |
-| Encryption and Key Management | azure | HIGH | Ensure that 'Secure transfer required' is enabled for Storage Accounts | accurics.azure.EKM.7 |
+| Infrastructure Security | azure | HIGH | Ensure 'Trusted Microsoft Services' is enabled for Storage Account access | accurics.azure.NS.2 |
+| Infrastructure Security | azure | HIGH | Ensure default network access rule for Storage Accounts is not open to public | accurics.azure.NS.4 |
+| Data Protection | azure | HIGH | Ensure that 'Secure transfer required' is enabled for Storage Accounts | accurics.azure.EKM.7 |
 
 
 ### azurerm_sql_server
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Monitoring | azure | MEDIUM | Ensure that 'Auditing' is set to 'On' for SQL servers | accurics.azure.MON.354 |
+| Logging and Monitoring | azure | MEDIUM | Ensure that 'Auditing' is set to 'On' for SQL servers | accurics.azure.MON.354 |
 | Identity and Access Management | azure | HIGH | Ensure that Azure Active Directory Admin is configured for SQL Server | accurics.azure.IAM.10 |
-| Identity and Access Management | azure | MEDIUM | Avoid using names like 'Admin' for an Azure SQL Server admin account login | accurics.azure.IAM.138 |
-| Logging | azure | MEDIUM | Ensure that 'Auditing' Retention is 'greater than 90 days' for SQL servers. | accurics.azure.LOG.356 |
+| Compliance Validation | azure | MEDIUM | Avoid using names like 'Admin' for an Azure SQL Server admin account login | accurics.azure.IAM.138 |
+| Compliance Validation | azure | LOW | Ensure that 'Auditing' Retention is 'greater than 90 days' for SQL servers. | accurics.azure.LOG.356 |
 
 
 ### azurerm_postgresql_configuration
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Logging | azure | MEDIUM | Ensure server parameter 'log_duration' is set to 'ON' for PostgreSQL Database Server | accurics.azure.LOG.154 |
-| Logging | azure | MEDIUM | Ensure server parameter 'log_retention_days' is greater than 3 days for PostgreSQL Database Server | accurics.azure.LOG.155 |
-| Logging | azure | MEDIUM | Ensure server parameter 'log_connections' is set to 'ON' for PostgreSQL Database Server | accurics.azure.LOG.152 |
-| Logging | azure | MEDIUM | Ensure server parameter 'log_checkpoints' is set to 'ON' for PostgreSQL Database Server | accurics.azure.LOG.364 |
-| Logging | azure | MEDIUM | Ensure server parameter 'log_disconnections' is set to 'ON' for PostgreSQL Database Server | accurics.azure.LOG.153 |
-| Logging | azure | MEDIUM | Ensure server parameter 'connection_throttling' is set to 'ON' for PostgreSQL Database Server | accurics.azure.LOG.151 |
+| Logging and Monitoring | azure | MEDIUM | Ensure server parameter 'log_duration' is set to 'ON' for PostgreSQL Database Server | accurics.azure.LOG.154 |
+| Logging and Monitoring | azure | MEDIUM | Ensure server parameter 'log_retention_days' is greater than 3 days for PostgreSQL Database Server | accurics.azure.LOG.155 |
+| Logging and Monitoring | azure | MEDIUM | Ensure server parameter 'log_connections' is set to 'ON' for PostgreSQL Database Server | accurics.azure.LOG.152 |
+| Logging and Monitoring | azure | MEDIUM | Ensure server parameter 'log_checkpoints' is set to 'ON' for PostgreSQL Database Server | accurics.azure.LOG.364 |
+| Logging and Monitoring | azure | MEDIUM | Ensure server parameter 'log_disconnections' is set to 'ON' for PostgreSQL Database Server | accurics.azure.LOG.153 |
+| Logging and Monitoring | azure | MEDIUM | Ensure server parameter 'connection_throttling' is set to 'ON' for PostgreSQL Database Server | accurics.azure.LOG.151 |
 
 
 ### azurerm_sql_database
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Monitoring | azure | MEDIUM | Ensure that 'Threat Detection' is enabled for Azure SQL Database | accurics.azure.MON.157 |
+| Logging and Monitoring | azure | MEDIUM | Ensure that 'Threat Detection' is enabled for Azure SQL Database | accurics.azure.MON.157 |
 
 
 ### azurerm_redis_cache
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | HIGH | Ensure that Redis is updated regularly with security and operational updates.Note this feature is only available to Premium tier Redis Caches. | accurics.azure.NS.13 |
-| Encryption and Key Management | azure | MEDIUM | Ensure that the Redis Cache accepts only SSL connections | accurics.azure.EKM.23 |
-| Network Security | azure | HIGH | Ensure there are no firewall rules allowing unrestricted access to Redis from other Azure sources | accurics.azure.NS.31 |
-| Network Security | azure | HIGH | Ensure there are no firewall rules allowing unrestricted access to Redis from the Internet | accurics.azure.NS.30 |
-| Network Security | azure | MEDIUM | Ensure there are no firewall rules allowing Redis Cache access for a large number of source IPs | accurics.azure.NS.166 |
+| Security Best Practices | azure | HIGH | Ensure that Redis is updated regularly with security and operational updates.Note this feature is only available to Premium tier Redis Caches. | accurics.azure.NS.13 |
+| Infrastructure Security | azure | MEDIUM | Ensure that the Redis Cache accepts only SSL connections | accurics.azure.EKM.23 |
+| Infrastructure Security | azure | HIGH | Ensure there are no firewall rules allowing unrestricted access to Redis from other Azure sources | accurics.azure.NS.31 |
+| Infrastructure Security | azure | HIGH | Ensure there are no firewall rules allowing unrestricted access to Redis from the Internet | accurics.azure.NS.30 |
+| Infrastructure Security | azure | MEDIUM | Ensure there are no firewall rules allowing Redis Cache access for a large number of source IPs | accurics.azure.NS.166 |
 
 
 ### azurerm_mssql_server
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Monitoring | azure | MEDIUM | Ensure that 'Auditing' is set to 'On' for MSSQL servers | accurics.azure.MON.355 |
-| Monitoring | azure | MEDIUM | Ensure that 'Auditing' Retention is 'greater than 90 days' for MSSQL servers. | accurics.azure.LOG.357 |
+| Logging and Monitoring | azure | MEDIUM | Ensure that 'Auditing' is set to 'On' for MSSQL servers | accurics.azure.MON.355 |
+| Logging and Monitoring | azure | MEDIUM | Ensure that 'Auditing' Retention is 'greater than 90 days' for MSSQL servers. | accurics.azure.LOG.357 |
 
 
 ### azurerm_kubernetes_cluster
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | MEDIUM | Ensure Kube Dashboard is disabled | accurics.azure.NS.383 |
-| Network Security | azure | MEDIUM | Ensure AKS cluster has Network Policy configured. | accurics.azure.NS.382 |
+| Infrastructure Security | azure | MEDIUM | Ensure Kube Dashboard is disabled | accurics.azure.NS.383 |
+| Infrastructure Security | azure | MEDIUM | Ensure AKS cluster has Network Policy configured. | accurics.azure.NS.382 |
 
 
 ### azurerm_managed_disk
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | azure | MEDIUM | Ensure that 'OS disk' are encrypted | accurics.azure.EKM.156 |
+| Data Protection | azure | MEDIUM | Ensure that 'Unattached disks' are encrypted in Azure Managed Disk | accurics.azure.EKM.156 |
 
 
 ### azurerm_network_watcher_flow_log
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | MEDIUM | Network Security Group Flow Logs should be enabled and the retention period is set to greater than or equal to 90 days. Flow logs enable capturing information about IP traffic flowing in and out of network security groups. Logs can be used to check for anomalies and give insight into suspected breaches. | accurics.azure.NS.342 |
-| Network Security | azure | HIGH | Enable Network Watcher for Azure subscriptions. Network diagnostic and visualization tools available with Network Watcher help users understand, diagnose, and gain insights to the network in Azure. | accurics.azure.NS.11 |
+| Resilience | azure | MEDIUM | Ensure that Network Security Group Flow Log retention period is 'greater than 90 days' for Azure Network Watcher Flow Log | accurics.azure.NS.342 |
+| Logging and Monitoring | azure | HIGH | Enable Network Watcher for Azure subscriptions. Network diagnostic and visualization tools available with Network Watcher help users understand, diagnose, and gain insights to the network in Azure. | accurics.azure.NS.11 |
 
 
 ### azurerm_key_vault_secret
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Key Management | azure | HIGH | Ensure that the expiration date is set on all secrets | accurics.azure.EKM.26 |
+| Data Protection | azure | HIGH | Ensure that the expiration date is set on all secrets | accurics.azure.EKM.26 |
 
 
 ### azurerm_key_vault_key
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Key Management | azure | HIGH | Ensure that the expiration date is set on all keys | accurics.azure.EKM.25 |
+| Data Protection | azure | HIGH | Ensure that the expiration date is set on all keys | accurics.azure.EKM.25 |
 
 
 ### azurerm_security_center_contact
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Monitoring | azure | MEDIUM | Ensure that 'Send email notification for high severity alerts' is set to 'On' | accurics.azure.MON.353 |
+| Logging and Monitoring | azure | MEDIUM | Ensure that 'Send email notification for high severity alerts' is set to 'On' | accurics.azure.MON.353 |
 
 
 ### azurerm_network_security_rule
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Ports Security | azure | LOW | VNC Listener (TCP:5500) is exposed to small Private network | accurics.azure.NPS.314 |
-| Network Ports Security | azure | MEDIUM | VNC Listener (TCP:5500) is exposed to small Public network | accurics.azure.NPS.251 |
-| Network Ports Security | azure | MEDIUM | Cassandra OpsCenter (TCP:61621) is exposed to wide Private network | accurics.azure.NPS.178 |
-| Network Ports Security | azure | MEDIUM | Memcached SSL (TCP:11214) is exposed to small Public network | accurics.azure.NPS.197 |
-| Network Ports Security | azure | MEDIUM | Microsoft-DS (TCP:445) is exposed to wide Private network | accurics.azure.NPS.206 |
-| Network Ports Security | azure | HIGH | NetBIOS Name Service (TCP:137) is exposed to wide Public network | accurics.azure.NPS.76 |
-| Network Ports Security | azure | HIGH | Prevalent known internal port (TCP:3000) is exposed to entire Public network | accurics.azure.NPS.99 |
-| Network Ports Security | azure | MEDIUM | MySQL (TCP:3306) is exposed to wide Private network | accurics.azure.NPS.210 |
-| Network Ports Security | azure | HIGH | MSSQL Server (TCP:1433) is exposed to wide Public network | accurics.azure.NPS.60 |
-| Network Ports Security | azure | LOW | POP3 (TCP:110) is exposed to small Private network | accurics.azure.NPS.302 |
-| Network Ports Security | azure | MEDIUM | SaltStack Master (TCP:4506) is exposed to small Public network | accurics.azure.NPS.247 |
-| Network Ports Security | azure | HIGH | SSH (TCP:22) is exposed to the wide public internet | accurics.azure.NPS.37 |
-| Network Ports Security | azure | MEDIUM | Hadoop Name Node (TCP:9000) is exposed to small Public network | accurics.azure.NPS.181 |
-| Network Ports Security | azure | HIGH | Telnet (TCP:23) is exposed to entire Public network | accurics.azure.NPS.115 |
-| Network Ports Security | azure | LOW | MSSQL Browser (UDP:1434) is exposed to small Private network | accurics.azure.NPS.284 |
-| Network Ports Security | azure | LOW | Mongo Web Portal (TCP:27018) is exposed to small Private network | accurics.azure.NPS.292 |
-| Network Ports Security | azure | HIGH | SMTP (TCP:25) is exposed to entire Public network | accurics.azure.NPS.103 |
-| Network Ports Security | azure | MEDIUM | CIFS / SMB (TCP:3020) is exposed to wide Private network | accurics.azure.NPS.174 |
-| Network Ports Security | azure | HIGH | PostgreSQL (TCP:5432) is exposed to entire Public network | accurics.azure.NPS.95 |
-| Network Ports Security | azure | HIGH | NetBIOS Datagram Service (UDP:138) is exposed to entire Public network | accurics.azure.NPS.83 |
-| Network Ports Security | azure | HIGH | VNC Server (TCP:5900) is exposed to entire Public network | accurics.azure.NPS.119 |
-| Network Ports Security | azure | HIGH | Cassandra (TCP:7001) is exposed to wide Public network | accurics.azure.NPS.40 |
-| Network Ports Security | azure | MEDIUM | PostgreSQL (TCP:5432) is exposed to wide Private network | accurics.azure.NPS.230 |
-| Network Ports Security | azure | LOW | Memcached SSL (TCP:11215) is exposed to small Private network | accurics.azure.NPS.288 |
-| Network Ports Security | azure | HIGH | MSSQL Browser (UDP:1434) is exposed to wide Public network | accurics.azure.NPS.56 |
-| Network Ports Security | azure | MEDIUM | Oracle DB SSL (UDP:2484) is exposed to wide Private network | accurics.azure.NPS.226 |
-| Network Ports Security | azure | MEDIUM | POP3 (TCP:110) is exposed to small Public network | accurics.azure.NPS.227 |
-| Network Ports Security | azure | HIGH | MSSQL Browser (UDP:1434) is exposed to entire Public network | accurics.azure.NPS.57 |
-| Network Ports Security | azure | LOW | Memcached SSL (UDP:11214) is exposed to small Private network | accurics.azure.NPS.289 |
-| Network Ports Security | azure | MEDIUM | PostgreSQL (UDP:5432) is exposed to small Public network | accurics.azure.NPS.231 |
-| Network Ports Security | azure | HIGH | VNC Server (TCP:5900) is exposed to wide Public network | accurics.azure.NPS.118 |
-| Network Ports Security | azure | HIGH | Cassandra (TCP:7001) is exposed to entire Public network | accurics.azure.NPS.41 |
-| Network Ports Security | azure | HIGH | NetBIOS Datagram Service (UDP:138) is exposed to wide Public network | accurics.azure.NPS.82 |
-| Network Ports Security | azure | HIGH | PostgreSQL (TCP:5432) is exposed to wide Public network | accurics.azure.NPS.94 |
-| Network Ports Security | azure | MEDIUM | Cassandra (TCP:7001) is exposed to small Public network | accurics.azure.NPS.175 |
-| Network Ports Security | azure | HIGH | SMTP (TCP:25) is exposed to wide Public network | accurics.azure.NPS.102 |
-| Network Ports Security | azure | LOW | MySQL (TCP:3306) is exposed to small Private network | accurics.azure.NPS.293 |
-| Network Ports Security | azure | LOW | MSSQL Debugger (TCP:135) is exposed to small Private network | accurics.azure.NPS.285 |
-| Network Ports Security | azure | HIGH | Telnet (TCP:23) is exposed to wide Public network | accurics.azure.NPS.114 |
-| Network Ports Security | azure | HIGH | Remote Desktop (TCP:3389) is exposed to the wide public internet | accurics.azure.NPS.36 |
-| Network Ports Security | azure | MEDIUM | DNS (UDP:53) is exposed to wide Private network | accurics.azure.NPS.180 |
-| Network Ports Security | azure | LOW | PostgreSQL (TCP:5432) is exposed to small Private network | accurics.azure.NPS.303 |
-| Network Ports Security | azure | MEDIUM | SaltStack Master (TCP:4505) is exposed to wide Private network | accurics.azure.NPS.246 |
-| Network Ports Security | azure | HIGH | MSSQL Server (TCP:1433) is exposed to entire Public network | accurics.azure.NPS.61 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Name Service (TCP:137) is exposed to small Public network | accurics.azure.NPS.211 |
-| Network Ports Security | azure | HIGH | NetBIOS Name Service (TCP:137) is exposed to entire Public network | accurics.azure.NPS.77 |
-| Network Ports Security | azure | HIGH | Prevalent known internal port (TCP:3000) is exposed to wide Public network | accurics.azure.NPS.98 |
-| Network Ports Security | azure | MEDIUM | Mongo Web Portal (TCP:27018) is exposed to small Public network | accurics.azure.NPS.207 |
-| Network Ports Security | azure | MEDIUM | DNS (UDP:53) is exposed to small Public network | accurics.azure.NPS.179 |
-| Network Ports Security | azure | MEDIUM | MSSQL Server (TCP:1433) is exposed to wide Private network | accurics.azure.NPS.196 |
-| Network Ports Security | azure | LOW | VNC Server (TCP:5900) is exposed to small Private network | accurics.azure.NPS.315 |
-| Network Ports Security | azure | MEDIUM | Telnet (TCP:23) is exposed to wide Private network | accurics.azure.NPS.250 |
-| Network Ports Security | azure | HIGH | SSH (TCP:22) is exposed to the entire public internet | accurics.azure.NPS.172 |
-| Network Ports Security | azure | HIGH | POP3 (TCP:110) is exposed to entire Public network | accurics.azure.NPS.93 |
-| Network Ports Security | azure | HIGH | NetBIOS Session Service (TCP:139) is exposed to entire Public network | accurics.azure.NPS.85 |
-| Network Ports Security | azure | LOW | SNMP (UDP:161) is exposed to small Private network | accurics.azure.NPS.308 |
-| Network Ports Security | azure | HIGH | Hadoop Name Node (TCP:9000) is exposed to wide Public network | accurics.azure.NPS.46 |
-| Network Ports Security | azure | MEDIUM | Puppet Master (TCP:8140) is exposed to wide Private network | accurics.azure.NPS.236 |
-| Network Ports Security | azure | LOW | Cassandra OpsCenter (TCP:61621) is exposed to small Private network | accurics.azure.NPS.277 |
-| Network Ports Security | azure | LOW | NetBIOS Session Service (TCP:139) is exposed to small Private network | accurics.azure.NPS.298 |
-| Network Ports Security | azure | HIGH | SQL Server Analysis (TCP:2383) is exposed to entire Public network | accurics.azure.NPS.109 |
-| Network Ports Security | azure | HIGH |  Known internal web port (TCP:8080) is exposed to wide Public network | accurics.azure.NPS.50 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Session Service (TCP:139) is exposed to wide Private network | accurics.azure.NPS.220 |
-| Network Ports Security | azure | LOW | SaltStack Master (TCP:4506) is exposed to small Private network | accurics.azure.NPS.312 |
-| Network Ports Security | azure | MEDIUM | MSSQL Browser (UDP:1434) is exposed to small Public network | accurics.azure.NPS.191 |
-| Network Ports Security | azure | MEDIUM | Memcached SSL (TCP:11215) is exposed to wide Private network | accurics.azure.NPS.200 |
-| Network Ports Security | azure | HIGH | Microsoft-DS (TCP:445) is exposed to wide Public network | accurics.azure.NPS.70 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Datagram Service (TCP:138) is exposed to wide Private network | accurics.azure.NPS.216 |
-| Network Ports Security | azure | HIGH | Memcached SSL (UDP:11214) is exposed to wide Public network | accurics.azure.NPS.66 |
-| Network Ports Security | azure | HIGH | Oracle DB SSL (TCP:2484) is exposed to entire Public network | accurics.azure.NPS.89 |
-| Network Ports Security | azure | LOW | PostgreSQL (UDP:5432) is exposed to small Private network | accurics.azure.NPS.304 |
-| Network Ports Security | azure | MEDIUM | SQL Server Analysis (TCP:2382) is exposed to small Public network | accurics.azure.NPS.241 |
-| Network Ports Security | azure | MEDIUM | LDAP SSL (TCP:636) is exposed to small Public network | accurics.azure.NPS.187 |
-| Network Ports Security | azure | HIGH | SaltStack Master (TCP:4506) is exposed to entire Public network | accurics.azure.NPS.113 |
-| Network Ports Security | azure | LOW | LDAP SSL (TCP:636) is exposed to small Private network | accurics.azure.NPS.282 |
-| Network Ports Security | azure | LOW | NetBIOS Name Service (TCP:137) is exposed to small Private network | accurics.azure.NPS.294 |
-| Network Ports Security | azure | HIGH | SNMP (UDP:161) is exposed to entire Public network | accurics.azure.NPS.105 |
-| Network Ports Security | azure | HIGH | SNMP (UDP:161) is exposed to wide Public network | accurics.azure.NPS.104 |
-| Network Ports Security | azure | LOW | NetBIOS Name Service (UDP:137) is exposed to small Private network | accurics.azure.NPS.295 |
-| Network Ports Security | azure | LOW | MSSQL Admin (TCP:1434) is exposed to small Private network | accurics.azure.NPS.283 |
-| Network Ports Security | azure | HIGH | SaltStack Master (TCP:4506) is exposed to wide Public network | accurics.azure.NPS.112 |
-| Network Ports Security | azure | MEDIUM |  Known internal web port (TCP:8080) is exposed to wide Private network | accurics.azure.NPS.186 |
-| Network Ports Security | azure | LOW | Prevalent known internal port (TCP:3000) is exposed to small Private network | accurics.azure.NPS.305 |
-| Network Ports Security | azure | MEDIUM | SNMP (UDP:161) is exposed to wide Private network | accurics.azure.NPS.240 |
-| Network Ports Security | azure | HIGH | Memcached SSL (UDP:11214) is exposed to entire Public network | accurics.azure.NPS.67 |
-| Network Ports Security | azure | HIGH | Oracle DB SSL (TCP:2484) is exposed to wide Public network | accurics.azure.NPS.88 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Datagram Service (UDP:138) is exposed to small Public network | accurics.azure.NPS.217 |
-| Network Ports Security | azure | HIGH | Microsoft-DS (TCP:445) is exposed to entire Public network | accurics.azure.NPS.71 |
-| Network Ports Security | azure | MEDIUM | Memcached SSL (UDP:11214) is exposed to small Public network | accurics.azure.NPS.201 |
-| Network Ports Security | azure | MEDIUM | MSSQL Admin (TCP:1434) is exposed to wide Private network | accurics.azure.NPS.190 |
-| Network Ports Security | azure | LOW | Telnet (TCP:23) is exposed to small Private network | accurics.azure.NPS.313 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Session Service (UDP:139) is exposed to small Public network | accurics.azure.NPS.221 |
-| Network Ports Security | azure | HIGH | SQL Server Analysis (TCP:2383) is exposed to wide Public network | accurics.azure.NPS.108 |
-| Network Ports Security | azure | HIGH |  Known internal web port (TCP:8080) is exposed to entire Public network | accurics.azure.NPS.51 |
-| Network Ports Security | azure | LOW | Cassandra (TCP:7001) is exposed to small Private network | accurics.azure.NPS.276 |
-| Network Ports Security | azure | LOW | NetBIOS Session Service (UDP:139) is exposed to small Private network | accurics.azure.NPS.299 |
-| Network Ports Security | azure | MEDIUM | SMTP (TCP:25) is exposed to small Public network | accurics.azure.NPS.237 |
-| Network Ports Security | azure | HIGH | Hadoop Name Node (TCP:9000) is exposed to entire Public network | accurics.azure.NPS.47 |
-| Network Ports Security | azure | LOW | SQL Server Analysis (TCP:2382) is exposed to small Private network | accurics.azure.NPS.309 |
-| Network Ports Security | azure | HIGH | NetBIOS Session Service (TCP:139) is exposed to wide Public network | accurics.azure.NPS.84 |
-| Network Ports Security | azure | HIGH | POP3 (TCP:110) is exposed to wide Public network | accurics.azure.NPS.92 |
-| Network Ports Security | azure | MEDIUM | CIFS / SMB (TCP:3020) is exposed to small Public network | accurics.azure.NPS.173 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Session Service (UDP:139) is exposed to wide Private network | accurics.azure.NPS.222 |
-| Network Ports Security | azure | HIGH | LDAP SSL (TCP:636) is exposed to wide Public network | accurics.azure.NPS.52 |
-| Network Ports Security | azure | LOW | CIFS / SMB (TCP:3020) is exposed to small Private network | accurics.azure.NPS.275 |
-| Network Ports Security | azure | MEDIUM | Prevalent known internal port (TCP:3000) is exposed to wide Private network | accurics.azure.NPS.234 |
-| Network Ports Security | azure | HIGH | DNS (UDP:53) is exposed to wide Public network | accurics.azure.NPS.44 |
-| Network Ports Security | azure | MEDIUM | MSSQL Admin (TCP:1434) is exposed to small Public network | accurics.azure.NPS.189 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Datagram Service (UDP:138) is exposed to wide Private network | accurics.azure.NPS.218 |
-| Network Ports Security | azure | HIGH | NetBIOS Session Service (UDP:139) is exposed to entire Public network | accurics.azure.NPS.87 |
-| Network Ports Security | azure | HIGH | Memcached SSL (UDP:11215) is exposed to wide Public network | accurics.azure.NPS.68 |
-| Network Ports Security | azure | HIGH | Oracle DB SSL (UDP:2484) is exposed to entire Public network | accurics.azure.NPS.91 |
-| Network Ports Security | azure | HIGH | CiscoSecure, WebSM (TCP:9090) is exposed to the entire public internet | accurics.azure.NPS.170 |
-| Network Ports Security | azure | HIGH | SQL Server Analysis (TCP:2382) is exposed to entire Public network | accurics.azure.NPS.107 |
-| Network Ports Security | azure | LOW | NetBIOS Datagram Service (TCP:138) is exposed to small Private network | accurics.azure.NPS.296 |
-| Network Ports Security | azure | LOW | Hadoop Name Node (TCP:9000) is exposed to small Private network | accurics.azure.NPS.279 |
-| Network Ports Security | azure | LOW |  Known internal web port (TCP:8000) is exposed to small Private network | accurics.azure.NPS.280 |
-| Network Ports Security | azure | HIGH |  Known internal web port (TCP:8000) is exposed to wide Public network | accurics.azure.NPS.48 |
-| Network Ports Security | azure | HIGH | SaltStack Master (TCP:4505) is exposed to entire Public network | accurics.azure.NPS.111 |
-| Network Ports Security | azure | MEDIUM | SMTP (TCP:25) is exposed to wide Private network | accurics.azure.NPS.238 |
-| Network Ports Security | azure | MEDIUM |  Known internal web port (TCP:8080) is exposed to small Public network | accurics.azure.NPS.185 |
-| Network Ports Security | azure | MEDIUM | SQL Server Analysis (TCP:2383) is exposed to small Public network | accurics.azure.NPS.243 |
-| Network Ports Security | azure | LOW | Puppet Master (TCP:8140) is exposed to small Private network | accurics.azure.NPS.306 |
-| Network Ports Security | azure | HIGH | Memcached SSL (TCP:11215) is exposed to wide Public network | accurics.azure.NPS.64 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Name Service (UDP:137) is exposed to wide Private network | accurics.azure.NPS.214 |
-| Network Ports Security | azure | HIGH | Mongo Web Portal (TCP:27018) is exposed to wide Public network | accurics.azure.NPS.72 |
-| Network Ports Security | azure | MEDIUM | Memcached SSL (UDP:11214) is exposed to wide Private network | accurics.azure.NPS.202 |
-| Network Ports Security | azure | MEDIUM | MSSQL Debugger (TCP:135) is exposed to small Public network | accurics.azure.NPS.193 |
-| Network Ports Security | azure | LOW | SQL Server Analysis (TCP:2383) is exposed to small Private network | accurics.azure.NPS.310 |
-| Network Ports Security | azure | MEDIUM | VNC Server (TCP:5900) is exposed to wide Private network | accurics.azure.NPS.254 |
-| Network Ports Security | azure | LOW | SaltStack Master (TCP:4505) is exposed to small Private network | accurics.azure.NPS.311 |
-| Network Ports Security | azure | MEDIUM | MSSQL Browser (UDP:1434) is exposed to wide Private network | accurics.azure.NPS.192 |
-| Network Ports Security | azure | MEDIUM | Memcached SSL (UDP:11215) is exposed to small Public network | accurics.azure.NPS.203 |
-| Network Ports Security | azure | HIGH | Mongo Web Portal (TCP:27018) is exposed to entire Public network | accurics.azure.NPS.73 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Datagram Service (TCP:138) is exposed to small Public network | accurics.azure.NPS.215 |
-| Network Ports Security | azure | HIGH | Memcached SSL (TCP:11215) is exposed to entire Public network | accurics.azure.NPS.65 |
-| Network Ports Security | azure | MEDIUM | SQL Server Analysis (TCP:2382) is exposed to wide Private network | accurics.azure.NPS.242 |
-| Network Ports Security | azure | LOW | SMTP (TCP:25) is exposed to small Private network | accurics.azure.NPS.307 |
-| Network Ports Security | azure | MEDIUM |  Known internal web port (TCP:8000) is exposed to wide Private network | accurics.azure.NPS.184 |
-| Network Ports Security | azure | MEDIUM | SNMP (UDP:161) is exposed to small Public network | accurics.azure.NPS.239 |
-| Network Ports Security | azure | HIGH |  Known internal web port (TCP:8000) is exposed to entire Public network | accurics.azure.NPS.49 |
-| Network Ports Security | azure | HIGH | SaltStack Master (TCP:4505) is exposed to wide Public network | accurics.azure.NPS.110 |
-| Network Ports Security | azure | LOW |  Known internal web port (TCP:8080) is exposed to small Private network | accurics.azure.NPS.281 |
-| Network Ports Security | azure | LOW | NetBIOS Datagram Service (UDP:138) is exposed to small Private network | accurics.azure.NPS.297 |
-| Network Ports Security | azure | LOW | DNS (UDP:53) is exposed to small Private network | accurics.azure.NPS.278 |
-| Network Ports Security | azure | HIGH | SQL Server Analysis (TCP:2382) is exposed to wide Public network | accurics.azure.NPS.106 |
-| Network Ports Security | azure | HIGH | Remote Desktop (TCP:3389) is exposed to the entire public internet | accurics.azure.NPS.171 |
-| Network Ports Security | azure | HIGH | Oracle DB SSL (UDP:2484) is exposed to wide Public network | accurics.azure.NPS.90 |
-| Network Ports Security | azure | HIGH | NetBIOS Session Service (UDP:139) is exposed to wide Public network | accurics.azure.NPS.86 |
-| Network Ports Security | azure | HIGH | Memcached SSL (UDP:11215) is exposed to entire Public network | accurics.azure.NPS.69 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Session Service (TCP:139) is exposed to small Public network | accurics.azure.NPS.219 |
-| Network Ports Security | azure | MEDIUM | LDAP SSL (TCP:636) is exposed to wide Private network | accurics.azure.NPS.188 |
-| Network Ports Security | azure | HIGH | DNS (UDP:53) is exposed to entire Public network | accurics.azure.NPS.45 |
-| Network Ports Security | azure | MEDIUM | Puppet Master (TCP:8140) is exposed to small Public network | accurics.azure.NPS.235 |
-| Network Ports Security | azure | HIGH | LDAP SSL (TCP:636) is exposed to entire Public network | accurics.azure.NPS.53 |
-| Network Ports Security | azure | MEDIUM | Oracle DB SSL (TCP:2484) is exposed to small Public network | accurics.azure.NPS.223 |
-| Network Ports Security | azure | HIGH | MSSQL Debugger (TCP:135) is exposed to wide Public network | accurics.azure.NPS.58 |
-| Network Ports Security | azure | HIGH | Puppet Master (TCP:8140) is exposed to entire Public network | accurics.azure.NPS.101 |
-| Network Ports Security | azure | MEDIUM | POP3 (TCP:110) is exposed to wide Private network | accurics.azure.NPS.228 |
-| Network Ports Security | azure | LOW | Memcached SSL (UDP:11215) is exposed to small Private network | accurics.azure.NPS.290 |
-| Network Ports Security | azure | LOW | MSSQL Server (TCP:1433) is exposed to small Private network | accurics.azure.NPS.286 |
-| Network Ports Security | azure | HIGH | VNC Listener (TCP:5500) is exposed to entire Public network | accurics.azure.NPS.117 |
-| Network Ports Security | azure | MEDIUM |  Known internal web port (TCP:8000) is exposed to small Public network | accurics.azure.NPS.183 |
-| Network Ports Security | azure | HIGH | CiscoSecure, WebSM (TCP:9090) is exposed to the wide public internet | accurics.azure.NPS.35 |
-| Network Ports Security | azure | MEDIUM | SaltStack Master (TCP:4505) is exposed to small Public network | accurics.azure.NPS.245 |
-| Network Ports Security | azure | LOW | Oracle DB SSL (TCP:2484) is exposed to small Private network | accurics.azure.NPS.300 |
-| Network Ports Security | azure | HIGH | Memcached SSL (TCP:11214) is exposed to wide Public network | accurics.azure.NPS.62 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Name Service (TCP:137) is exposed to wide Private network | accurics.azure.NPS.212 |
-| Network Ports Security | azure | HIGH | MySQL (TCP:3306) is exposed to wide Public network | accurics.azure.NPS.74 |
-| Network Ports Security | azure | MEDIUM | Memcached SSL (UDP:11215) is exposed to wide Private network | accurics.azure.NPS.204 |
-| Network Ports Security | azure | MEDIUM | MSSQL Server (TCP:1433) is exposed to small Public network | accurics.azure.NPS.195 |
-| Network Ports Security | azure | MEDIUM | VNC Server (TCP:5900) is exposed to small Public network | accurics.azure.NPS.253 |
-| Network Ports Security | azure | MEDIUM | Oracle DB SSL (TCP:2484) is exposed to wide Private network | accurics.azure.NPS.224 |
-| Network Ports Security | azure | HIGH | MSSQL Admin (TCP:1434) is exposed to wide Public network | accurics.azure.NPS.54 |
-| Network Ports Security | azure | MEDIUM | PostgreSQL (UDP:5432) is exposed to wide Private network | accurics.azure.NPS.232 |
-| Network Ports Security | azure | HIGH | Cassandra OpsCenter (TCP:61621) is exposed to wide Public network | accurics.azure.NPS.42 |
-| Network Ports Security | azure | MEDIUM | Telnet (TCP:23) is exposed to small Public network | accurics.azure.NPS.249 |
-| Network Ports Security | azure | HIGH | CIFS / SMB (TCP:3020) is exposed to entire Public network | accurics.azure.NPS.39 |
-| Network Ports Security | azure | HIGH | NetBIOS Datagram Service (TCP:138) is exposed to entire Public network | accurics.azure.NPS.81 |
-| Network Ports Security | azure | MEDIUM | Mongo Web Portal (TCP:27018) is exposed to wide Private network | accurics.azure.NPS.208 |
-| Network Ports Security | azure | HIGH | PostgreSQL (UDP:5432) is exposed to entire Public network | accurics.azure.NPS.97 |
-| Network Ports Security | azure | HIGH | NetBIOS Name Service (UDP:137) is exposed to wide Public network | accurics.azure.NPS.78 |
-| Network Ports Security | azure | MEDIUM | Memcached SSL (TCP:11215) is exposed to small Public network | accurics.azure.NPS.199 |
-| Network Ports Security | azure | MEDIUM | Cassandra (TCP:7001) is exposed to wide Private network | accurics.azure.NPS.176 |
-| Network Ports Security | azure | MEDIUM | Memcached SSL (TCP:11214) is exposed to wide Private network | accurics.azure.NPS.198 |
-| Network Ports Security | azure | MEDIUM | Cassandra OpsCenter (TCP:61621) is exposed to small Public network | accurics.azure.NPS.177 |
-| Network Ports Security | azure | HIGH | PostgreSQL (UDP:5432) is exposed to wide Public network | accurics.azure.NPS.96 |
-| Network Ports Security | azure | HIGH | NetBIOS Name Service (UDP:137) is exposed to entire Public network | accurics.azure.NPS.79 |
-| Network Ports Security | azure | MEDIUM | MySQL (TCP:3306) is exposed to small Public network | accurics.azure.NPS.209 |
-| Network Ports Security | azure | HIGH | NetBIOS Datagram Service (TCP:138) is exposed to wide Public network | accurics.azure.NPS.80 |
-| Network Ports Security | azure | HIGH | CIFS / SMB (TCP:3020) is exposed to wide Public network | accurics.azure.NPS.38 |
-| Network Ports Security | azure | MEDIUM | SaltStack Master (TCP:4506) is exposed to wide Private network | accurics.azure.NPS.248 |
-| Network Ports Security | azure | HIGH | Cassandra OpsCenter (TCP:61621) is exposed to entire Public network | accurics.azure.NPS.43 |
-| Network Ports Security | azure | MEDIUM | Prevalent known internal port (TCP:3000) is exposed to small Public network | accurics.azure.NPS.233 |
-| Network Ports Security | azure | HIGH | MSSQL Admin (TCP:1434) is exposed to entire Public network | accurics.azure.NPS.55 |
-| Network Ports Security | azure | MEDIUM | Oracle DB SSL (UDP:2484) is exposed to small Public network | accurics.azure.NPS.225 |
-| Network Ports Security | azure | MEDIUM | VNC Listener (TCP:5500) is exposed to wide Private network | accurics.azure.NPS.252 |
-| Network Ports Security | azure | MEDIUM | MSSQL Debugger (TCP:135) is exposed to wide Private network | accurics.azure.NPS.194 |
-| Network Ports Security | azure | MEDIUM | Microsoft-DS (TCP:445) is exposed to small Public network | accurics.azure.NPS.205 |
-| Network Ports Security | azure | HIGH | MySQL (TCP:3306) is exposed to entire Public network | accurics.azure.NPS.75 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Name Service (UDP:137) is exposed to small Public network | accurics.azure.NPS.213 |
-| Network Ports Security | azure | HIGH | Memcached SSL (TCP:11214) is exposed to entire Public network | accurics.azure.NPS.63 |
-| Network Ports Security | azure | MEDIUM | SQL Server Analysis (TCP:2383) is exposed to wide Private network | accurics.azure.NPS.244 |
-| Network Ports Security | azure | LOW | Oracle DB SSL (UDP:2484) is exposed to small Private network | accurics.azure.NPS.301 |
-| Network Ports Security | azure | MEDIUM | Hadoop Name Node (TCP:9000) is exposed to wide Private network | accurics.azure.NPS.182 |
-| Network Ports Security | azure | HIGH | VNC Listener (TCP:5500) is exposed to wide Public network | accurics.azure.NPS.116 |
-| Network Ports Security | azure | LOW | Memcached SSL (TCP:11214) is exposed to small Private network | accurics.azure.NPS.287 |
-| Network Ports Security | azure | LOW | Microsoft-DS (TCP:445) is exposed to small Private network | accurics.azure.NPS.291 |
-| Network Ports Security | azure | MEDIUM | PostgreSQL (TCP:5432) is exposed to small Public network | accurics.azure.NPS.229 |
-| Network Ports Security | azure | HIGH | MSSQL Debugger (TCP:135) is exposed to entire Public network | accurics.azure.NPS.59 |
-| Network Ports Security | azure | HIGH | Puppet Master (TCP:8140) is exposed to wide Public network | accurics.azure.NPS.100 |
+| Infrastructure Security | json | MEDIUM | Ensure Known internal web port (Tcp:8000) is not exposed to public for Azure Network Security Rule | AC_AZURE_0528 |
+| Infrastructure Security | json | LOW | Ensure NetBIOS Name Service (Udp:137) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0482 |
+| Infrastructure Security | json | LOW | Ensure Microsoft-DS (Tcp:445) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0494 |
+| Infrastructure Security | json | LOW | Ensure MSSQL Debugger (Tcp:135) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0512 |
+| Infrastructure Security | json | HIGH | Ensure PostgreSQL (Udp:5432) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0457 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (Tcp:11215) is not exposed to public for Azure Network Security Rule | AC_AZURE_0504 |
+| Infrastructure Security | json | MEDIUM | Ensure SQL Server Analysis (Tcp:2382) is not exposed to public for Azure Network Security Rule | AC_AZURE_0441 |
+| Infrastructure Security | json | LOW | Ensure POP3 (Tcp:110) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0461 |
+| Infrastructure Security | json | LOW | Ensure Known internal web port (Tcp:8080) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0524 |
+| Infrastructure Security | json | HIGH | Ensure SaltStack Master (Tcp:4505) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0436 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBIOS Datagram Service (Udp:138) is not exposed to public for Azure Network Security Rule | AC_AZURE_0477 |
+| Infrastructure Security | json | HIGH | Ensure Hadoop Name Node (Tcp:9000) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0532 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (Udp:11215) is not exposed to public for Azure Network Security Rule | AC_AZURE_0498 |
+| Infrastructure Security | json | MEDIUM | Ensure CIFS / SMB (Tcp:3020) is not exposed to public for Azure Network Security Rule | AC_AZURE_0271 |
+| Infrastructure Security | json | HIGH | Ensure Memcached SSL (Tcp:11214) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0508 |
+| Infrastructure Security | json | LOW | Ensure MSSQL Server (Tcp:1433) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0509 |
+| Infrastructure Security | json | HIGH | Ensure CIFS / SMB (Tcp:3020) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0270 |
+| Infrastructure Security | json | LOW | Ensure NetBIOS Datagram Service (Udp:138) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0476 |
+| Infrastructure Security | json | LOW | Ensure DNS (Udp:53) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0533 |
+| Infrastructure Security | json | HIGH | Ensure Memcached SSL (Udp:11215) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0499 |
+| Infrastructure Security | json | LOW | Ensure server is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0421 |
+| Infrastructure Security | json | LOW | Ensure SQL Server Analysis (Tcp:2383) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0437 |
+| Infrastructure Security | json | HIGH | Ensure PostgreSQL (Tcp:5432) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0460 |
+| Infrastructure Security | json | MEDIUM | Ensure Known internal web port (Tcp:8080) is not exposed to public for Azure Network Security Rule | AC_AZURE_0525 |
+| Infrastructure Security | json | HIGH | Ensure Memcached SSL (Tcp:11215) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0505 |
+| Infrastructure Security | json | LOW | Ensure SQL Server Analysis (Tcp:2382) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0440 |
+| Infrastructure Security | json | HIGH | Ensure SSH (Tcp:22) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0285 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Debugger (Tcp:135) is not exposed to public for Azure Network Security Rule | AC_AZURE_0513 |
+| Infrastructure Security | json | MEDIUM | Ensure PostgreSQL (Udp:5432) is not exposed to public for Azure Network Security Rule | AC_AZURE_0456 |
+| Infrastructure Security | json | MEDIUM | Ensure Microsoft-DS (Tcp:445) is not exposed to public for Azure Network Security Rule | AC_AZURE_0495 |
+| Infrastructure Security | json | HIGH | Ensure that RDP access is restricted from the internet for Azure Network Security Rule | AC_AZURE_0342 |
+| Infrastructure Security | json | HIGH | Ensure Known internal web port (Tcp:8000) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0529 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBIOS Name Service (Udp:137) is not exposed to public for Azure Network Security Rule | AC_AZURE_0483 |
+| Infrastructure Security | json | LOW | Ensure Oracle DB SSL (Tcp:2484) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0467 |
+| Infrastructure Security | json | LOW | Ensure MySQL (Tcp:3306) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0488 |
+| Infrastructure Security | json | MEDIUM | Ensure LDAP SSL (Tcp:636) is not exposed to public for Azure Network Security Rule | AC_AZURE_0522 |
+| Infrastructure Security | json | HIGH | Ensure Telnet (Tcp:23) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0430 |
+| Infrastructure Security | json | MEDIUM | Ensure VNC Listener (Tcp:5500) is not exposed to public for Azure Network Security Rule | AC_AZURE_0426 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBIOS Session Service (Udp:139) is not exposed to public for Azure Network Security Rule | AC_AZURE_0471 |
+| Infrastructure Security | json | MEDIUM | Ensure DNS (Udp:53) is not exposed to public for Azure Network Security Rule | AC_AZURE_0534 |
+| Infrastructure Security | json | LOW | Ensure MSSQL Admin (Tcp:1434) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0518 |
+| Infrastructure Security | json | HIGH | Ensure NetBIOS Name Service (Udp:137) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0484 |
+| Infrastructure Security | json | MEDIUM | Ensure Mongo Web Portal (Tcp:27018) is not exposed to public for Azure Network Security Rule | AC_AZURE_0492 |
+| Infrastructure Security | json | HIGH | Ensure MSSQL Debugger (Tcp:135) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0514 |
+| Infrastructure Security | json | HIGH | Ensure Puppet Master (Tcp:8140) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0451 |
+| Infrastructure Security | json | HIGH | Ensure Memcached SSL (Udp:11214) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0502 |
+| Infrastructure Security | json | MEDIUM | Ensure SMTP (Tcp:25) is not exposed to public for Azure Network Security Rule | AC_AZURE_0447 |
+| Infrastructure Security | json | LOW | Ensure Memcached SSL (Tcp:11215) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0503 |
+| Infrastructure Security | json | LOW | Ensure SMTP (Tcp:25) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0446 |
+| Infrastructure Security | json | LOW | Ensure MSSQL Browser (Udp:1434) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0515 |
+| Infrastructure Security | json | MEDIUM | Ensure Puppet Master (Tcp:8140) is not exposed to public for Azure Network Security Rule | AC_AZURE_0450 |
+| Infrastructure Security | json | HIGH | Ensure Mongo Web Portal (Tcp:27018) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0493 |
+| Infrastructure Security | json | LOW | Ensure NetBIOS Name Service (Tcp:137) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0485 |
+| Infrastructure Security | json | HIGH | Ensure Cassandra OpsCenter (Tcp:61621) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0276 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Admin (Tcp:1434) is not exposed to public for Azure Network Security Rule | AC_AZURE_0519 |
+| Infrastructure Security | json | LOW | Ensure NetBIOS Session Service (Udp:139) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0470 |
+| Infrastructure Security | json | HIGH | Ensure DNS (Udp:53) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0535 |
+| Infrastructure Security | json | HIGH | Ensure VNC Listener (Tcp:5500) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0427 |
+| Infrastructure Security | json | LOW | Ensure SaltStack Master (Tcp:4506) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0431 |
+| Infrastructure Security | json | HIGH | Ensure Oracle DB SSL (Udp:2484) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0466 |
+| Infrastructure Security | json | MEDIUM | Ensure MySQL (Tcp:3306) is not exposed to public for Azure Network Security Rule | AC_AZURE_0489 |
+| Infrastructure Security | json | HIGH | Ensure LDAP SSL (Tcp:636) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0523 |
+| Infrastructure Security | json | LOW | Ensure Puppet Master (Tcp:8140) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0449 |
+| Infrastructure Security | json | LOW | Ensure Cassandra (Tcp:7001) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0275 |
+| Infrastructure Security | json | LOW | Ensure Cassandra OpsCenter (Tcp:61621) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0536 |
+| Infrastructure Security | json | LOW | Ensure NetBIOS Session Service (Tcp:139) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0473 |
+| Infrastructure Security | json | HIGH | Ensure VNC Server (Tcp:5900) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0424 |
+| Infrastructure Security | json | MEDIUM | Ensure SaltStack Master (Tcp:4506) is not exposed to public for Azure Network Security Rule | AC_AZURE_0432 |
+| Infrastructure Security | json | HIGH | Ensure MSSQL Admin (Tcp:1434) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0520 |
+| Infrastructure Security | json | MEDIUM | Ensure Oracle DB SSL (Udp:2484) is not exposed to public for Azure Network Security Rule | AC_AZURE_0465 |
+| Infrastructure Security | json | HIGH | Ensure SNMP (Udp:161) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0445 |
+| Infrastructure Security | json | LOW | Ensure Memcached SSL (Udp:11214) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0500 |
+| Infrastructure Security | json | MEDIUM | Ensure Prevalent known internal port (Tcp:3000) is not exposed to public for Azure Network Security Rule | AC_AZURE_0453 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Browser (Udp:1434) is not exposed to public for Azure Network Security Rule | AC_AZURE_0516 |
+| Infrastructure Security | json | HIGH | Ensure MySQL (Tcp:3306) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0490 |
+| Infrastructure Security | json | LOW | Ensure Telnet (Tcp:23) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0428 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBIOS Name Service (Tcp:137) is not exposed to public for Azure Network Security Rule | AC_AZURE_0486 |
+| Infrastructure Security | json | HIGH | Ensure Oracle DB SSL (Tcp:2484) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0469 |
+| Infrastructure Security | json | HIGH | Ensure NetBIOS Name Service (Tcp:137) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0487 |
+| Infrastructure Security | json | MEDIUM | Ensure Oracle DB SSL (Tcp:2484) is not exposed to public for Azure Network Security Rule | AC_AZURE_0468 |
+| Infrastructure Security | json | MEDIUM | Ensure Telnet (Tcp:23) is not exposed to public for Azure Network Security Rule | AC_AZURE_0429 |
+| Infrastructure Security | json | LOW | Ensure Mongo Web Portal (Tcp:27018) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0491 |
+| Infrastructure Security | json | LOW | Ensure Prevalent known internal port (Tcp:3000) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0452 |
+| Infrastructure Security | json | HIGH | Ensure MSSQL Browser (Udp:1434) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0517 |
+| Infrastructure Security | json | MEDIUM | Ensure SNMP (Udp:161) is not exposed to public for Azure Network Security Rule | AC_AZURE_0444 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (Udp:11214) is not exposed to public for Azure Network Security Rule | AC_AZURE_0501 |
+| Infrastructure Security | json | LOW | Ensure LDAP SSL (Tcp:636) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0521 |
+| Infrastructure Security | json | LOW | Ensure Oracle DB SSL (Udp:2484) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0464 |
+| Infrastructure Security | json | HIGH | Ensure SaltStack Master (Tcp:4506) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0433 |
+| Infrastructure Security | json | LOW | Ensure VNC Listener (Tcp:5500) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0425 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra OpsCenter (Tcp:61621) is not exposed to public for Azure Network Security Rule | AC_AZURE_0537 |
+| Infrastructure Security | json | HIGH | Ensure NetBIOS Session Service (Udp:139) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0472 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra (Tcp:7001) is not exposed to public for Azure Network Security Rule | AC_AZURE_0274 |
+| Infrastructure Security | json | HIGH | Ensure SMTP (Tcp:25) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0448 |
+| Infrastructure Security | json | LOW | Ensure SNMP (Udp:161) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0443 |
+| Infrastructure Security | json | LOW | Ensure Memcached SSL (Tcp:11214) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0506 |
+| Infrastructure Security | json | MEDIUM | Ensure SSH (Tcp:22) is not exposed to public for Azure Network Security Rule | AC_AZURE_0286 |
+| Infrastructure Security | json | LOW | Ensure PostgreSQL (Udp:5432) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0455 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Server (Tcp:1433) is not exposed to public for Azure Network Security Rule | AC_AZURE_0510 |
+| Infrastructure Security | json | HIGH | Ensure Microsoft-DS (Tcp:445) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0496 |
+| Infrastructure Security | json | LOW | Ensure NetBIOS Datagram Service (Tcp:138) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0479 |
+| Infrastructure Security | json | HIGH | Ensure that request initiated from all ports (*) for all destination ports (*) is restricted from the internet for Azure Network Security Rule | AC_AZURE_0357 |
+| Infrastructure Security | json | MEDIUM | Ensure SQL Server Analysis (Tcp:2383) is not exposed to public for Azure Network Security Rule | AC_AZURE_0438 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBIOS Datagram Service (Tcp:138) is not exposed to public for Azure Network Security Rule | AC_AZURE_0480 |
+| Infrastructure Security | json | HIGH | Ensure Cassandra (Tcp:7001) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0273 |
+| Infrastructure Security | json | MEDIUM | Ensure PostgreSQL (Tcp:5432) is not exposed to public for Azure Network Security Rule | AC_AZURE_0459 |
+| Infrastructure Security | json | LOW | Ensure Hadoop Name Node (Tcp:9000) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0530 |
+| Infrastructure Security | json | HIGH | Ensure NetBIOS Session Service (Tcp:139) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0475 |
+| Infrastructure Security | json | LOW | Ensure VNC Server (Tcp:5900) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0422 |
+| Infrastructure Security | json | LOW | Ensure SaltStack Master (Tcp:4505) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0434 |
+| Infrastructure Security | json | HIGH | Ensure Known internal web port (Tcp:8080) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0526 |
+| Infrastructure Security | json | HIGH | Ensure POP3 (Tcp:110) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0463 |
+| Infrastructure Security | json | LOW | Ensure Known internal web port (Tcp:8000) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0527 |
+| Infrastructure Security | json | MEDIUM | Ensure POP3 (Tcp:110) is not exposed to public for Azure Network Security Rule | AC_AZURE_0462 |
+| Infrastructure Security | json | MEDIUM | Ensure SaltStack Master (Tcp:4505) is not exposed to public for Azure Network Security Rule | AC_AZURE_0435 |
+| Infrastructure Security | json | MEDIUM | Ensure VNC Server (Tcp:5900) is not exposed to public for Azure Network Security Rule | AC_AZURE_0423 |
+| Infrastructure Security | json | MEDIUM | Ensure Hadoop Name Node (Tcp:9000) is not exposed to public for Azure Network Security Rule | AC_AZURE_0531 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBIOS Session Service (Tcp:139) is not exposed to public for Azure Network Security Rule | AC_AZURE_0474 |
+| Infrastructure Security | json | LOW | Ensure PostgreSQL (Tcp:5432) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0458 |
+| Infrastructure Security | json | LOW | Ensure CIFS / SMB (Tcp:3020) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0272 |
+| Infrastructure Security | json | HIGH | Ensure NetBIOS Datagram Service (Tcp:138) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0481 |
+| Infrastructure Security | json | HIGH | Ensure SQL Server Analysis (Tcp:2383) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0439 |
+| Infrastructure Security | json | LOW | Ensure Memcached SSL (Udp:11215) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0497 |
+| Infrastructure Security | json | HIGH | Ensure NetBIOS Datagram Service (Udp:138) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0478 |
+| Infrastructure Security | json | HIGH | Ensure Prevalent known internal port (Tcp:3000) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0454 |
+| Infrastructure Security | json | HIGH | Ensure MSSQL Server (Tcp:1433) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0511 |
+| Infrastructure Security | json | LOW | Ensure SSH (Tcp:22) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0287 |
+| Infrastructure Security | json | HIGH | Ensure SQL Server Analysis (Tcp:2382) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0442 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (Tcp:11214) is not exposed to public for Azure Network Security Rule | AC_AZURE_0507 |
 
 
 ### azurerm_cosmosdb_account
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | HIGH | Ensure to filter source Ips for Cosmos DB Account | accurics.azure.NS.32 |
-| Cloud Assets Management | azure | MEDIUM | Ensure that Cosmos DB Account has an associated tag | accurics.azure.CAM.162 |
+| Infrastructure Security | azure | HIGH | Ensure to filter source Ips for Cosmos DB Account | accurics.azure.NS.32 |
+| Compliance Validation | azure | MEDIUM | Ensure that Cosmos DB Account has an associated tag | accurics.azure.CAM.162 |
 
 
 ### azurerm_security_center_subscription_pricing
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Operational Efficiency | azure | MEDIUM | Ensure that standard pricing tiers are selected | accurics.azure.OPS.349 |
+| Security Best Practices | azure | MEDIUM | Ensure that standard pricing tiers are selected | accurics.azure.OPS.349 |
 
 
 ### azurerm_sql_active_directory_administrator
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Identity and Access Management | azure | MEDIUM | Avoid using names like 'Admin' for an Azure SQL Server Active Directory Administrator account | accurics.azure.IAM.137 |
+| Compliance Validation | azure | MEDIUM | Avoid using names like 'Admin' for an Azure SQL Server Active Directory Administrator account | accurics.azure.IAM.137 |
 
 
 ### azurerm_container_registry
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | azure | MEDIUM | Ensure that admin user is disabled for Container Registry | accurics.azure.EKM.164 |
-| Azure Container Services | azure | HIGH | Ensure Container Registry has locks | accurics.azure.AKS.3 |
+| Identity and Access Management | azure | MEDIUM | Ensure that admin user is disabled for Container Registry | accurics.azure.EKM.164 |
+| Resilience | azure | HIGH | Ensure Container Registry has locks | accurics.azure.AKS.3 |
 
 
 ### azurerm_virtual_network
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | MEDIUM | Ensure that Azure Virtual Network subnet is configured with a Network Security Group | accurics.azure.NS.161 |
+| Infrastructure Security | azure | MEDIUM | Ensure that Azure Virtual Network subnet is configured with a Network Security Group | accurics.azure.NS.161 |
 
 
 ### azurerm_role_assignment
@@ -398,13 +310,13 @@ description: >
 ### azurerm_application_gateway
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | MEDIUM | Ensure Azure Application Gateway Web application firewall (WAF) is enabled | accurics.azure.NS.147 |
+| Infrastructure Security | azure | MEDIUM | Ensure Azure Application Gateway Web application firewall (WAF) is enabled | accurics.azure.NS.147 |
 
 
 ### azurerm_postgresql_server
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | azure | HIGH | Ensure 'Enforce SSL connection' is set to 'ENABLED' for PostgreSQL Database Server | accurics.azure.EKM.1 |
-| Backup and Disaster Recovery | azure | HIGH | Ensure that Geo Redundant Backups is enabled on PostgreSQL | accurics.azure.BDR.163 |
+| Infrastructure Security | azure | HIGH | Ensure 'Enforce SSL connection' is set to 'ENABLED' for PostgreSQL Database Server | accurics.azure.EKM.1 |
+| Resilience | azure | MEDIUM | Ensure that Geo Redundant Backups is enabled on PostgreSQL | accurics.azure.BDR.163 |
 
 

--- a/content/en/docs/Policies/docker.md
+++ b/content/en/docs/Policies/docker.md
@@ -1,0 +1,36 @@
+---
+title: "Docker Policies"
+linkTitle: "Docker Policies"
+weight: 60
+description: >
+
+---
+
+### docker_from
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Infrastructure Security | json | MEDIUM | Ensure platform flag with FROM command is not used for Docker file | AC_DOCKER_0001 |
+
+
+### docker_expose
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Infrastructure Security | json | HIGH | Ensure range of ports is from 0 to 65535 | AC_DOCKER_0011 |
+
+
+### docker_run
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Infrastructure Security | json | MEDIUM | Ensure Pinned Pip Package Version | AC_DOCKER_0010 |
+| Infrastructure Security | json | HIGH | Ensure to avoid RUN with sudo command | AC_DOCKER_0007 |
+| Infrastructure Security | json | MEDIUM | Ensure apt is not used with RUN command for Docker file | AC_DOCKER_0002 |
+| Infrastructure Security | json | MEDIUM | Ensure dnf Update is not used for Docker file | AC_DOCKER_0003 |
+| Infrastructure Security | json | MEDIUM | Ensure yum install allow manual input with RUN command for Docker file | AC_DOCKER_0004 |
+| Infrastructure Security | json | MEDIUM | Ensure Yum Clean All is used after Yum Install | AC_DOCKER_0009 |
+| Infrastructure Security | json | MEDIUM | Ensure root with RUN command is not used for Docker file | AC_DOCKER_0005 |
+
+
+### docker_workdir
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Infrastructure Security | json | HIGH | Ensure the use absolute paths for your WORKDIR. | AC_DOCKER_0013 |

--- a/content/en/docs/Policies/gcp.md
+++ b/content/en/docs/Policies/gcp.md
@@ -3,157 +3,338 @@ title: "GCP Policies"
 linkTitle: "GCP Policies"
 weight: 40
 description: >
-      
----
 
+---
 
 ### google_container_node_pool
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Operational Efficiency | gcp | HIGH | Ensure 'Automatic node upgrade' is enabled for Kubernetes Clusters. | accurics.gcp.OPS.101 |
-| Operational Efficiency | gcp | HIGH | Ensure Container-Optimized OS (cos) is used for Kubernetes Engine Clusters Node image. | accurics.gcp.OPS.114 |
-| Operational Efficiency | gcp | MEDIUM | Ensure 'Automatic node repair' is enabled for Kubernetes Clusters. | accurics.gcp.OPS.144 |
+| Security Best Practices | gcp | LOW | Ensure 'Automatic node upgrade' is enabled for Kubernetes Clusters. | accurics.gcp.OPS.101 |
+| Compliance Validation | gcp | HIGH | Ensure Container-Optimized OS (cos) is used for Kubernetes Engine Clusters Node image. | accurics.gcp.OPS.114 |
+| Security Best Practices | gcp | LOW | Ensure 'Automatic node repair' is enabled for Kubernetes Clusters. | accurics.gcp.OPS.144 |
 
 
 ### github_repository
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Identity & Access Management | gcp | MEDIUM | Repository is Not Private. | accurics.gcp.IAM.145 |
+| Identity and Access Management | gcp | MEDIUM | Repository is Not Private. | accurics.gcp.IAM.145 |
 
 
 ### google_bigquery_dataset
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Identity & Access Management | gcp | HIGH | BigQuery datasets may be anonymously or publicly accessible. | accurics.gcp.IAM.106 |
+| Identity and Access Management | gcp | HIGH | BigQuery datasets may be anonymously or publicly accessible. | accurics.gcp.IAM.106 |
 
 
 ### google_compute_project_metadata
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Access Control | gcp | HIGH | Ensure oslogin is enabled for a Project | accurics.gcp.IAM.127 |
+| Identity and Access Management | gcp | HIGH | Ensure oslogin is enabled for a Project | accurics.gcp.IAM.127 |
 
 
 ### google_compute_subnetwork
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Logging  | gcp | MEDIUM | Ensure that VPC Flow Logs is enabled for every subnet in a VPC Network. | accurics.gcp.LOG.118 |
+| Logging and Monitoring | gcp | MEDIUM | Ensure that VPC Flow Logs is enabled for every subnet in a VPC Network. | accurics.gcp.LOG.118 |
 
 
 ### google_project_iam_audit_config
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Logging | gcp | HIGH | Ensure that Cloud Audit Logging is configured properly across all services and all users from a project. | accurics.gcp.LOG.010 |
+| Logging and Monitoring | gcp | LOW | Ensure that Cloud Audit Logging is configured properly across all services and all users from a project. | accurics.gcp.LOG.010 |
 
 
 ### google_sql_database_instance
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Backup & Disaster Recovery | gcp | HIGH | Ensure all Cloud SQL database instance have backup configuration enabled. | accurics.gcp.BDR.105 |
-| Network Security | gcp | HIGH | Ensure that Cloud SQL database Instances are not open to the world. | accurics.gcp.NS.102 |
-| Encryption & Key Management | gcp | HIGH | Ensure that Cloud SQL database instance requires all incoming connections to use SSL | accurics.gcp.EKM.141 |
+| Resilience | gcp | HIGH | Ensure all Cloud SQL database instance have backup configuration enabled. | accurics.gcp.BDR.105 |
+| Infrastructure Security | gcp | HIGH | Ensure that Cloud SQL database Instances are not open to the world. | accurics.gcp.NS.102 |
+| Infrastructure Security | gcp | HIGH | Ensure that Cloud SQL database instance requires all incoming connections to use SSL | accurics.gcp.EKM.141 |
 
 
 ### google_compute_instance
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | gcp | MEDIUM | Ensure IP forwarding is not enabled on Instances. | accurics.gcp.NS.130 |
-| Network Security | gcp | MEDIUM | Ensure 'Block Project-wide SSH keys' is enabled for VM instances. | accurics.gcp.NS.126 |
-| Encryption & Key Management | gcp | MEDIUM | VM disks attached to a compute instance should be encrypted with Customer Supplied Encryption Keys (CSEK) . | accurics.gcp.EKM.132 |
-| Identity & Access Management | gcp | MEDIUM | Instances may have been configured to use the default service account with full access to all Cloud APIs | accurics.gcp.IAM.124 |
-| Network Security | gcp | MEDIUM | Ensure 'Enable connecting to serial ports' is not enabled for VM instances. | accurics.gcp.NS.129 |
-| Network Security  | gcp | MEDIUM | Ensure Compute instances are launched with Shielded VM enabled. | accurics.gcp.NS.133 |
-| Identity & Access Management | gcp | MEDIUM | Ensure that no instance in the project overrides the project setting for enabling OSLogin | accurics.gcp.IAM.128 |
-| Access Control | gcp | HIGH | Instances may have been configured to use the default service account with full access to all Cloud APIs | accurics.gcp.NS.125 |
+| Infrastructure Security | gcp | MEDIUM | Ensure IP forwarding is not enabled on Instances. | accurics.gcp.NS.130 |
+| Infrastructure Security | gcp | HIGH | Ensure 'Block Project-wide SSH keys' is enabled for VM instances. | accurics.gcp.NS.126 |
+| Data Protection | gcp | MEDIUM | VM disks attached to a compute instance should be encrypted with Customer Supplied Encryption Keys (CSEK) . | accurics.gcp.EKM.132 |
+| Identity and Access Management | gcp | HIGH | Instances may have been configured to use the default service account with full access to all Cloud APIs | accurics.gcp.IAM.124 |
+| Infrastructure Security | gcp | MEDIUM | Ensure 'Enable connecting to serial ports' is not enabled for VM instances. | accurics.gcp.NS.129 |
+| Infrastructure Security | gcp | MEDIUM | Ensure Compute instances are launched with Shielded VM enabled. | accurics.gcp.NS.133 |
+| Identity and Access Management | gcp | MEDIUM | Ensure that no instance in the project overrides the project setting for enabling OSLogin | accurics.gcp.IAM.128 |
+| Infrastructure Security | gcp | HIGH | Instances may have been configured to use the default service account with full access to all Cloud APIs | accurics.gcp.NS.125 |
 
 
 ### google_storage_bucket_iam_binding
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Identity & Access Management | gcp | MEDIUM | Ensure that Cloud Storage bucket is not anonymously or publicly accessible. | accurics.gcp.IAM.121 |
+| Identity and Access Management | gcp | MEDIUM | Ensure that Cloud Storage bucket is not anonymously or publicly accessible. | accurics.gcp.IAM.121 |
 
 
 ### google_container_cluster
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Monitoring | gcp | HIGH | Ensure Stackdriver Monitoring is enabled on Kubernetes Engine Clusters. | accurics.gcp.MON.143 |
-| Network Security | gcp | HIGH | Ensure Kubernetes Cluster is created with Private cluster enabled. | accurics.gcp.NS.117 |
-| Operational Efficiency | gcp | HIGH | Ensure PodSecurityPolicy controller is enabled on the Kubernetes Engine Clusters. | accurics.gcp.OPS.116 |
-| Identity & Access Management | gcp | HIGH | Ensure GKE basic auth is disabled. | accurics.gcp.IAM.110 |
-| Network Security | gcp | HIGH | Ensure Master Authentication is set to enabled on Kubernetes Engine Clusters. | accurics.gcp.NS.112 |
-| Operational Efficiency | gcp | HIGH | Ensure Kubernetes Cluster is created with Alias IP ranges enabled | accurics.gcp.OPS.115 |
-| Network Security | gcp | HIGH | Ensure GKE Control Plane is not public. | accurics.gcp.NS.109 |
-| Identity & Access Management | gcp | HIGH | Ensure Kubernetes Cluster is created with Client Certificate disabled. | accurics.gcp.IAM.104 |
-| Operational Efficiency | gcp | HIGH | Ensure Kubernetes Clusters are configured with Labels. | accurics.gcp.OPS.113 |
-| Identity & Access Management | gcp | HIGH | Ensure Legacy Authorization is set to disabled on Kubernetes Engine Clusters. | accurics.gcp.IAM.142 |
-| Logging | gcp | HIGH | Ensure Stackdriver Logging is enabled on Kubernetes Engine Clusters. | accurics.gcp.LOG.100 |
-| Network Security | gcp | HIGH | Ensure Network policy is enabled on Kubernetes Engine Clusters. | accurics.gcp.NS.103 |
+| Infrastructure Security | json | Medium | GKE Control Plane is exposed to few public IP addresses using master-authorized-network-config | AC-GC-IS-CC-M-0367 |
+| Logging and Monitoring | gcp | HIGH | Ensure Stackdriver Monitoring is enabled on Kubernetes Engine Clusters. | accurics.gcp.MON.143 |
+| Infrastructure Security | gcp | HIGH | Ensure Kubernetes Cluster is created with Private cluster enabled. | accurics.gcp.NS.117 |
+| Compliance Validation | gcp | HIGH | Ensure PodSecurityPolicy controller is enabled on the Kubernetes Engine Clusters. | accurics.gcp.OPS.116 |
+| Identity and Access Management | gcp | HIGH | Ensure GKE basic auth is disabled. | accurics.gcp.IAM.110 |
+| Infrastructure Security | gcp | HIGH | Ensure Master Authentication is set to enabled on Kubernetes Engine Clusters. | accurics.gcp.NS.112 |
+| Compliance Validation | gcp | HIGH | Ensure Kubernetes Cluster is created with Alias IP ranges enabled | accurics.gcp.OPS.115 |
+| Infrastructure Security | gcp | HIGH | Ensure GKE Control Plane is not public. | accurics.gcp.NS.109 |
+| Identity and Access Management | gcp | MEDIUM | Ensure Kubernetes Cluster is created with Client Certificate disabled. | accurics.gcp.IAM.104 |
+| Compliance Validation | gcp | HIGH | Ensure Kubernetes Clusters are configured with Labels. | accurics.gcp.OPS.113 |
+| Identity and Access Management | gcp | HIGH | Ensure Legacy Authorization is set to disabled on Kubernetes Engine Clusters. | accurics.gcp.IAM.142 |
+| Logging and Monitoring | gcp | HIGH | Ensure Stackdriver Logging is enabled on Kubernetes Engine Clusters. | accurics.gcp.LOG.100 |
+| Infrastructure Security | gcp | HIGH | Ensure Network policy is enabled on Kubernetes Engine Clusters. | accurics.gcp.NS.103 |
 
 
 ### google_project
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | gcp | MEDIUM | Ensure that the default network does not exist in a project. | accurics.gcp.NS.119 |
+| Infrastructure Security | gcp | MEDIUM | Ensure that the default network does not exist in a project. | accurics.gcp.NS.119 |
 
 
 ### google_compute_firewall
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | gcp | MEDIUM | Ensure that SSH access is restricted from the internet | accurics.gcp.NS.149 |
-| Network Security | gcp | MEDIUM | Ensure that SSH access is restricted from the internet | accurics.gcp.NS.148 |
-| Network Security  | gcp | MEDIUM | Ensure Google compute firewall ingress does not allow unrestricted rdp access. | accurics.gcp.NS.123 |
+| Infrastructure Security | json | MEDIUM | Ensure Puppet Master (TCP:8140) is not exposed to public for Google Compute Firewall | AC_GCP_0049 |
+| Infrastructure Security | json | HIGH | Ensure Remote Desktop (TCP:3389) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0225 |
+| Infrastructure Security | json | HIGH | Ensure LDAP SSL (TCP:636) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0161 |
+| Infrastructure Security | json | MEDIUM | Ensure SaltStack Master (TCP:4506) is not exposed to public for Google Compute Firewall | AC_GCP_0073 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra (TCP:7001) is not exposed to public for Google Compute Firewall | AC_GCP_0136 |
+| Infrastructure Security | json | HIGH | Ensure VNC Listener (TCP:5500) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0065 |
+| Infrastructure Security | json | LOW | Ensure Memcached SSL (UDP:11215) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0120 |
+| Infrastructure Security | json | MEDIUM | Ensure Oracle DB (TCP:1521) is not exposed to public for Google Compute Firewall | AC_GCP_0209 |
+| Infrastructure Security | json | HIGH | Ensure Cassandra Internode Communication (TCP:7000) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0198 |
+| Infrastructure Security | json | LOW | Ensure Elastic Search (TCP:9300) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0177 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBios Datagram Service (TCP:138) is not exposed to public for Google Compute Firewall | AC_GCP_0100 |
+| Infrastructure Security | json | LOW | Ensure Mongo Web Portal (TCP:27018) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0045 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Server (TCP:1433) is not exposed to public for Google Compute Firewall | AC_GCP_0157 |
+| Infrastructure Security | json | LOW | Ensure Postgres SQL (TCP:5432) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0141 |
+| Infrastructure Security | json | HIGH | Ensure Microsoft-DS (TCP:445) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0116 |
+| Infrastructure Security | json | HIGH | Ensure SQL Server Analysis Service browser (TCP:2382) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0053 |
+| Infrastructure Security | json | HIGH | Ensure Elastic Search (TCP:9200) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0182 |
+| Infrastructure Security | json | HIGH | Ensure LDAP (UDP:389) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0213 |
+| Infrastructure Security | json | LOW | Ensure NetBios Session Service (UDP:139) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0090 |
+| Infrastructure Security | json | LOW | Ensure Oracle DB (TCP:2483) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0205 |
+| Infrastructure Security | json | LOW | Ensure Known internal web port (TCP:8000) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0069 |
+| Infrastructure Security | json | HIGH | Ensure DNS (UDP:53) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0086 |
+| Infrastructure Security | json | HIGH | Ensure Cassandra Monitoring (TCP:7199) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0194 |
+| Infrastructure Security | json | HIGH | Ensure Known internal web port (TCP:8080) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0068 |
+| Infrastructure Security | json | LOW | Ensure SNMP (UDP:161) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0087 |
+| Infrastructure Security | json | HIGH | Ensure Oracle DB (UDP:2483) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0204 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBios Session Service (UDP:139) is not exposed to public for Google Compute Firewall | AC_GCP_0091 |
+| Infrastructure Security | json | MEDIUM | Ensure LDAP (UDP:389) is not exposed to public for Google Compute Firewall | AC_GCP_0212 |
+| Infrastructure Security | json | LOW | Ensure Cassandra Thrift (TCP:9160) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0183 |
+| Infrastructure Security | json | LOW | Ensure Telnet (TCP:23) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0117 |
+| Infrastructure Security | json | MEDIUM | Ensure SQL Server Analysis Service browser (TCP:2382) is not exposed to public for Google Compute Firewall | AC_GCP_0052 |
+| Infrastructure Security | json | HIGH | Ensure Postgres SQL (UDP:5432) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0140 |
+| Infrastructure Security | json | LOW | Ensure MSSQL Server (TCP:1433) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0156 |
+| Infrastructure Security | json | HIGH | Ensure NetBios Datagram Service (TCP:138) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0101 |
+| Infrastructure Security | json | HIGH | Ensure Cassandra OpsCenter agent (TCP:61621) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0044 |
+| Infrastructure Security | json | HIGH | Ensure SSH (TCP:20) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0228 |
+| Infrastructure Security | json | LOW | Ensure Redis (TCP:6379) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0199 |
+| Infrastructure Security | json | HIGH | Ensure Unencrypted Memcached Instances (TCP:11211) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0176 |
+| Infrastructure Security | json | LOW | Ensure Oracle DB (TCP:1521) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0208 |
+| Infrastructure Security | json | MEDIUM | Ensure VNC Listener (TCP:5500) is not exposed to public for Google Compute Firewall | AC_GCP_0064 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (UDP:11215) is not exposed to public for Google Compute Firewall | AC_GCP_0121 |
+| Infrastructure Security | json | LOW | Ensure SaltStack Master (TCP:4506) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0072 |
+| Infrastructure Security | json | HIGH | Ensure Cassandra (TCP:7001) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0137 |
+| Infrastructure Security | json | MEDIUM | Ensure LDAP SSL (TCP:636) is not exposed to public for Google Compute Firewall | AC_GCP_0160 |
+| Infrastructure Security | json | MEDIUM | Ensure Remote Desktop (TCP:3389) is not exposed to public for Google Compute Firewall | AC_GCP_0224 |
+| Infrastructure Security | json | LOW | Ensure Puppet Master (TCP:8140) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0048 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBIOS Name Service (TCP:137) is not exposed to public for Google Compute Firewall | AC_GCP_0106 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra OpsCenter agent (TCP:61621) is not exposed to public for Google Compute Firewall | AC_GCP_0043 |
+| Infrastructure Security | json | MEDIUM | Ensure Oracle DB SSL (TCP:2484) is not exposed to public for Google Compute Firewall | AC_GCP_0151 |
+| Infrastructure Security | json | LOW | Ensure Oracle DB SSL (UDP:2484) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0147 |
+| Infrastructure Security | json | HIGH | Ensure POP3 (TCP:110) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0110 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Browser Service (UDP:1434) is not exposed to public for Google Compute Firewall | AC_GCP_0055 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra Thrift (TCP:9160) is not exposed to public for Google Compute Firewall | AC_GCP_0184 |
+| Infrastructure Security | json | MEDIUM | Ensure LDAP (TCP:389) is not exposed to public for Google Compute Firewall | AC_GCP_0215 |
+| Infrastructure Security | json | MEDIUM | Ensure CIFS / SMB (TCP:3020) is not exposed to public for Google Compute Firewall | AC_GCP_0079 |
+| Infrastructure Security | json | LOW | Ensure NetBios Datagram Service (TCP:138) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0096 |
+| Infrastructure Security | json | MEDIUM | Ensure Oracle DB (UDP:2483) is not exposed to public for Google Compute Firewall | AC_GCP_0203 |
+| Infrastructure Security | json | HIGH | Ensure CIFS / SMB (TCP:3020) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0080 |
+| Infrastructure Security | json | LOW | Ensure Cassandra Monitoring (TCP:7199) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0192 |
+| Infrastructure Security | json | LOW | Ensure Remote Desktop (TCP:3389) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0223 |
+| Infrastructure Security | json | HIGH | Ensure MSSQL Admin (TCP:1434) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0059 |
+| Infrastructure Security | json | HIGH | Ensure Cassandra Client (TCP:9042) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0188 |
+| Infrastructure Security | json | HIGH | Ensure Cassandra OpsCenter Monitoring (TCP:61620) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0167 |
+| Infrastructure Security | json | LOW | Ensure SaltStack Master (TCP:4505) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0075 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (TCP:11214) is not exposed to public for Google Compute Firewall | AC_GCP_0130 |
+| Infrastructure Security | json | HIGH | Ensure CiscoSecure, Websm (TCP:9090) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0219 |
+| Infrastructure Security | json | LOW | Ensure VNC Listener (TCP:5500) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0063 |
+| Infrastructure Security | json | LOW | Ensure Memcached SSL (UDP:11214) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0126 |
+| Infrastructure Security | json | LOW | Ensure Unencrypted Memcached Instances (UDP:11211) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0171 |
+| Infrastructure Security | json | HIGH | Ensure Unencrypted Mongo Instances (TCP:27017) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0170 |
+| Infrastructure Security | json | HIGH | Ensure VNC Server (TCP:5900) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0062 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (UDP:11214) is not exposed to public for Google Compute Firewall | AC_GCP_0127 |
+| Infrastructure Security | json | MEDIUM | Ensure CiscoSecure, Websm (TCP:9090) is not exposed to public for Google Compute Firewall | AC_GCP_0218 |
+| Infrastructure Security | json | HIGH | Ensure SaltStack Master (TCP:4506) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0074 |
+| Infrastructure Security | json | HIGH | Ensure Memcached SSL (TCP:11214) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0131 |
+| Infrastructure Security | json | LOW | Ensure Cassandra OpsCenter Website (TCP:8888) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0189 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra OpsCenter Monitoring (TCP:61620) is not exposed to public for Google Compute Firewall | AC_GCP_0166 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Admin (TCP:1434) is not exposed to public for Google Compute Firewall | AC_GCP_0058 |
+| Infrastructure Security | json | HIGH | Ensure Hadoop Name Node (TCP:9000) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0222 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra Monitoring (TCP:7199) is not exposed to public for Google Compute Firewall | AC_GCP_0193 |
+| Infrastructure Security | json | LOW | Ensure Prevalent known internal port (TCP:3000) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0081 |
+| Infrastructure Security | json | LOW | Ensure Oracle DB (UDP:2483) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0202 |
+| Infrastructure Security | json | LOW | Ensure CIFS / SMB (TCP:3020) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0078 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBios Datagram Service (TCP:138) is not exposed to public for Google Compute Firewall | AC_GCP_0097 |
+| Infrastructure Security | json | LOW | Ensure LDAP (TCP:389) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0214 |
+| Infrastructure Security | json | HIGH | Ensure Cassandra Thrift (TCP:9160) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0185 |
+| Infrastructure Security | json | LOW | Ensure SMTP (TCP:25) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0111 |
+| Infrastructure Security | json | LOW | Ensure MSSQL Browser Service (UDP:1434) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0054 |
+| Infrastructure Security | json | HIGH | Ensure MySQL (TCP:3306) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0146 |
+| Infrastructure Security | json | LOW | Ensure Oracle DB SSL (TCP:2484) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0150 |
+| Infrastructure Security | json | HIGH | Ensure NetBIOS Name Service (TCP:137) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0107 |
+| Infrastructure Security | json | LOW | Ensure Cassandra OpsCenter agent (TCP:61621) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0042 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra OpsCenter Website (TCP:8888) is not exposed to public for Google Compute Firewall | AC_GCP_0190 |
+| Infrastructure Security | json | MEDIUM | Ensure Prevalent known internal port (TCP:3000) is not exposed to public for Google Compute Firewall | AC_GCP_0082 |
+| Infrastructure Security | json | HIGH | Ensure Memcached SSL (UDP:11214) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0128 |
+| Infrastructure Security | json | HIGH | Ensure Redis (TCP:6379) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0201 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBios Session Service (TCP:139) is not exposed to public for Google Compute Firewall | AC_GCP_0094 |
+| Infrastructure Security | json | LOW | Ensure CiscoSecure, Websm (TCP:9090) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0217 |
+| Infrastructure Security | json | MEDIUM | Ensure Unencrypted Mongo Instances (TCP:27017) is not exposed to public for Google Compute Firewall | AC_GCP_0169 |
+| Infrastructure Security | json | LOW | Ensure Cassandra Client (TCP:9042) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0186 |
+| Infrastructure Security | json | LOW | Ensure MSSQL Admin (TCP:1434) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0057 |
+| Infrastructure Security | json | MEDIUM | Ensure SMTP (TCP:25) is not exposed to public for Google Compute Firewall | AC_GCP_0112 |
+| Infrastructure Security | json | MEDIUM | Ensure MySQL (TCP:3306) is not exposed to public for Google Compute Firewall | AC_GCP_0145 |
+| Infrastructure Security | json | LOW | Ensure SQL Server Analysis Services (TCP:2383) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0153 |
+| Infrastructure Security | json | HIGH | Ensure NetBIOS Name Service (UDP:137) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0104 |
+| Infrastructure Security | json | HIGH | Ensure Unencrypted Memcached Instances (UDP:11211) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0173 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (TCP:11215) is not exposed to public for Google Compute Firewall | AC_GCP_0124 |
+| Infrastructure Security | json | MEDIUM | Ensure VNC Server (TCP:5900) is not exposed to public for Google Compute Firewall | AC_GCP_0061 |
+| Infrastructure Security | json | HIGH | Ensure NetBios Datagram Service (TCP:138) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0098 |
+| Infrastructure Security | json | LOW | Ensure Remote Desktop (TCP:3389) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0132 |
+| Infrastructure Security | json | HIGH | Ensure SaltStack Master (TCP:4505) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0077 |
+| Infrastructure Security | json | LOW | Ensure Cassandra OpsCenter Monitoring (TCP:61620) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0165 |
+| Infrastructure Security | json | HIGH | Ensure Oracle DB SSL (UDP:2484) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0149 |
+| Infrastructure Security | json | MEDIUM | Ensure Hadoop Name Node (TCP:9000) is not exposed to public for Google Compute Firewall | AC_GCP_0221 |
+| Infrastructure Security | json | LOW | Ensure POP3 (TCP:110) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0108 |
+| Infrastructure Security | json | MEDIUM | Ensure POP3 (TCP:110) is not exposed to public for Google Compute Firewall | AC_GCP_0109 |
+| Infrastructure Security | json | LOW | Ensure Hadoop Name Node (TCP:9000) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0220 |
+| Infrastructure Security | json | MEDIUM | Ensure Oracle DB SSL (UDP:2484) is not exposed to public for Google Compute Firewall | AC_GCP_0148 |
+| Infrastructure Security | json | HIGH | Ensure MSSQL Debugger (TCP:135) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0164 |
+| Infrastructure Security | json | LOW | Ensure NetBios Datagram Service (TCP:138) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0099 |
+| Infrastructure Security | json | MEDIUM | Ensure Remote Desktop (TCP:3389) is not exposed to public for Google Compute Firewall | AC_GCP_0133 |
+| Infrastructure Security | json | MEDIUM | Ensure SaltStack Master (TCP:4505) is not exposed to public for Google Compute Firewall | AC_GCP_0076 |
+| Infrastructure Security | json | HIGH | Ensure Memcached SSL (TCP:11215) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0125 |
+| Infrastructure Security | json | LOW | Ensure VNC Server (TCP:5900) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0060 |
+| Infrastructure Security | json | MEDIUM | Ensure Unencrypted Memcached Instances (UDP:11211) is not exposed to public for Google Compute Firewall | AC_GCP_0172 |
+| Infrastructure Security | json | LOW | Ensure NetBIOS Name Service (TCP:137) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0105 |
+| Infrastructure Security | json | HIGH | Ensure Oracle DB SSL (TCP:2484) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0152 |
+| Infrastructure Security | json | LOW | Ensure MySQL (TCP:3306) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0144 |
+| Infrastructure Security | json | HIGH | Ensure MSSQL Browser Service (UDP:1434) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0056 |
+| Infrastructure Security | json | HIGH | Ensure SMTP (TCP:25) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0113 |
+| Infrastructure Security | json | LOW | Ensure Unencrypted Mongo Instances (TCP:27017) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0168 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra Client (TCP:9042) is not exposed to public for Google Compute Firewall | AC_GCP_0187 |
+| Infrastructure Security | json | HIGH | Ensure LDAP (TCP:389) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0216 |
+| Infrastructure Security | json | HIGH | Ensure NetBios Session Service (TCP:139) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0095 |
+| Infrastructure Security | json | MEDIUM | Ensure Redis (TCP:6379) is not exposed to public for Google Compute Firewall | AC_GCP_0200 |
+| Infrastructure Security | json | HIGH | Ensure Prevalent known internal port (TCP:3000) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0083 |
+| Infrastructure Security | json | LOW | Ensure Memcached SSL (TCP:11214) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0129 |
+| Infrastructure Security | json | HIGH | Ensure Cassandra OpsCenter Website (TCP:8888) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0191 |
+| Infrastructure Security | json | MEDIUM | Ensure Unencrypted Memcached Instances (TCP:11211) is not exposed to public for Google Compute Firewall | AC_GCP_0175 |
+| Infrastructure Security | json | HIGH | Ensure Memcached SSL (UDP:11215) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0122 |
+| Infrastructure Security | json | MEDIUM | Ensure SNMP (UDP:161) is not exposed to public for Google Compute Firewall | AC_GCP_0088 |
+| Infrastructure Security | json | MEDIUM | Ensure Known internal web port (TCP:8080) is not exposed to public for Google Compute Firewall | AC_GCP_0067 |
+| Infrastructure Security | json | HIGH | Ensure Remote Desktop (TCP:3389) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0134 |
+| Infrastructure Security | json | HIGH | Ensure Known internal web port (TCP:8000) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0071 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Debugger (TCP:135) is not exposed to public for Google Compute Firewall | AC_GCP_0163 |
+| Infrastructure Security | json | MEDIUM | Ensure Telnet (TCP:23) is not exposed to public for Google Compute Firewall | AC_GCP_0118 |
+| Infrastructure Security | json | LOW | Ensure LDAP SSL (TCP:636) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0159 |
+| Infrastructure Security | json | MEDIUM | Ensure SSH (TCP:20) is not exposed to public for Google Compute Firewall | AC_GCP_0227 |
+| Infrastructure Security | json | HIGH | Ensure Elastic Search (TCP:9300) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0179 |
+| Infrastructure Security | json | LOW | Ensure Cassandra Internode Communication (TCP:7000) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0196 |
+| Infrastructure Security | json | LOW | Ensure DNS (UDP:53) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0084 |
+| Infrastructure Security | json | HIGH | Ensure Oracle DB (TCP:2483) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0207 |
+| Infrastructure Security | json | LOW | Ensure Postgres SQL (UDP:5432) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0138 |
+| Infrastructure Security | json | HIGH | Ensure NetBios Session Service (UDP:139) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0092 |
+| Infrastructure Security | json | LOW | Ensure LDAP (UDP:389) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0211 |
+| Infrastructure Security | json | LOW | Ensure Elastic Search (TCP:9200) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0180 |
+| Infrastructure Security | json | LOW | Ensure SQL Server Analysis Service browser (TCP:2382) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0051 |
+| Infrastructure Security | json | LOW | Ensure Microsoft-DS (TCP:445) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0114 |
+| Infrastructure Security | json | HIGH | Ensure Postgres SQL (TCP:5432) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0143 |
+| Infrastructure Security | json | HIGH | Ensure SQL Server Analysis Services (TCP:2383) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0155 |
+| Infrastructure Security | json | HIGH | Ensure Mongo Web Portal (TCP:27018) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0047 |
+| Infrastructure Security | json | LOW | Ensure NetBIOS Name Service (UDP:137) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0102 |
+| Infrastructure Security | json | MEDIUM | Ensure Mongo Web Portal (TCP:27018) is not exposed to public for Google Compute Firewall | AC_GCP_0046 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBIOS Name Service (UDP:137) is not exposed to public for Google Compute Firewall | AC_GCP_0103 |
+| Infrastructure Security | json | MEDIUM | Ensure SQL Server Analysis Services (TCP:2383) is not exposed to public for Google Compute Firewall | AC_GCP_0154 |
+| Infrastructure Security | json | MEDIUM | Ensure Postgres SQL (TCP:5432) is not exposed to public for Google Compute Firewall | AC_GCP_0142 |
+| Infrastructure Security | json | HIGH | Ensure Puppet Master (TCP:8140) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0050 |
+| Infrastructure Security | json | MEDIUM | Ensure Microsoft-DS (TCP:445) is not exposed to public for Google Compute Firewall | AC_GCP_0115 |
+| Infrastructure Security | json | MEDIUM | Ensure Elastic Search (TCP:9200) is not exposed to public for Google Compute Firewall | AC_GCP_0181 |
+| Infrastructure Security | json | HIGH | Ensure Oracle DB (TCP:1521) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0210 |
+| Infrastructure Security | json | MEDIUM | Ensure Postgres SQL (UDP:5432) is not exposed to public for Google Compute Firewall | AC_GCP_0139 |
+| Infrastructure Security | json | LOW | Ensure NetBios Session Service (TCP:139) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0093 |
+| Infrastructure Security | json | MEDIUM | Ensure Oracle DB (TCP:2483) is not exposed to public for Google Compute Firewall | AC_GCP_0206 |
+| Infrastructure Security | json | MEDIUM | Ensure DNS (UDP:53) is not exposed to public for Google Compute Firewall | AC_GCP_0085 |
+| Infrastructure Security | json | MEDIUM | Ensure Elastic Search (TCP:9300) is not exposed to public for Google Compute Firewall | AC_GCP_0178 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra Internode Communication (TCP:7000) is not exposed to public for Google Compute Firewall | AC_GCP_0197 |
+| Infrastructure Security | json | LOW | Ensure SSH (TCP:20) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0226 |
+| Infrastructure Security | json | HIGH | Ensure MSSQL Server (TCP:1433) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0158 |
+| Infrastructure Security | json | HIGH | Ensure Telnet (TCP:23) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0119 |
+| Infrastructure Security | json | LOW | Ensure MSSQL Debugger (TCP:135) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0162 |
+| Infrastructure Security | json | LOW | Ensure Cassandra (TCP:7001) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0135 |
+| Infrastructure Security | json | MEDIUM | Ensure Known internal web port (TCP:8000) is not exposed to public for Google Compute Firewall | AC_GCP_0070 |
+| Infrastructure Security | json | LOW | Ensure Memcached SSL (TCP:11215) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0123 |
+| Infrastructure Security | json | HIGH | Ensure SNMP (UDP:161) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0089 |
+| Infrastructure Security | json | LOW | Ensure Known internal web port (TCP:8080) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0066 |
+| Infrastructure Security | json | LOW | Ensure Unencrypted Memcached Instances (TCP:11211) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0174 |
 
 
 ### google_dns_managed_zone
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Encryption & Key Management | gcp | HIGH | Ensure that RSASHA1 is not used for the zone-signing and key-signing keys in Cloud DNS DNSSEC. | accurics.gcp.EKM.108 |
-| Network Security | gcp | HIGH | Ensure that DNSSEC is enabled for Cloud DNS. | accurics.gcp.NS.107 |
+| Infrastructure Security | gcp | HIGH | Ensure that RSASHA1 is not used for the zone-signing and key-signing keys in Cloud DNS DNSSEC. | accurics.gcp.EKM.108 |
+| Infrastructure Security | gcp | LOW | Ensure that DNSSEC is enabled for Cloud DNS. | accurics.gcp.NS.107 |
 
 
 ### google_compute_disk
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Encryption & Key Management | gcp | MEDIUM | Ensure VM disks for critical VMs are encrypted with Customer Supplied Encryption Keys (CSEK) . | accurics.gcp.EKM.131 |
+| Data Protection | gcp | MEDIUM | Ensure VM disks for critical VMs are encrypted with Customer Supplied Encryption Keys (CSEK) . | accurics.gcp.EKM.131 |
 
 
 ### google_project_iam_member
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Identity & Access Management | gcp | MEDIUM | Ensure that IAM users are not assigned the Service Account User or Service Account Token Creator roles at project level. | accurics.gcp.IAM.137 |
-| Identity & Access Management | gcp | MEDIUM | Ensure that Service Account has no Admin privileges. | accurics.gcp.IAM.138 |
+| Identity and Access Management | gcp | HIGH | Ensure that IAM users are not assigned the Service Account User or Service Account Token Creator roles at project level. | accurics.gcp.IAM.137 |
+| Identity and Access Management | gcp | HIGH | Ensure that Service Account has no Admin privileges. | accurics.gcp.IAM.138 |
 
 
 ### google_storage_bucket_iam_member
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Identity & Access Management | gcp | HIGH | Ensure that Cloud Storage bucket is not anonymously or publicly Accessible. | accurics.gcp.IAM.120 |
+| Identity and Access Management | gcp | HIGH | Ensure that Cloud Storage bucket is not anonymously or publicly Accessible. | accurics.gcp.IAM.120 |
 
 
 ### google_compute_ssl_policy
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Encryption & Key Management | gcp | MEDIUM | Ensure no HTTPS or SSL proxy load balancers permit SSL policies with weak cipher suites. | accurics.gcp.EKM.134 |
+| Infrastructure Security | gcp | MEDIUM | Ensure no HTTPS or SSL proxy load balancers permit SSL policies with weak cipher suites. | accurics.gcp.EKM.134 |
 
 
 ### google_storage_bucket
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Logging | gcp | HIGH | Ensure that logging is enabled for Cloud storage buckets. | accurics.gcp.LOG.147 |
-| Logging | gcp | HIGH | Ensure that object versioning is enabled on log-buckets. | accurics.gcp.LOG.146 |
-| Identity & Access Management | gcp | MEDIUM | Ensure that Cloud Storage buckets have uniform bucket-level access enabled. | accurics.gcp.IAM.122 |
+| Logging and Monitoring | gcp | HIGH | Ensure that logging is enabled for Cloud storage buckets. | accurics.gcp.LOG.147 |
+| Logging and Monitoring | gcp | HIGH | Ensure that object versioning is enabled on log-buckets. | accurics.gcp.LOG.146 |
+| Identity and Access Management | gcp | MEDIUM | Ensure that Cloud Storage buckets have uniform bucket-level access enabled. | accurics.gcp.IAM.122 |
 
 
 ### google_kms_crypto_key
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Encryption & Key Management | gcp | MEDIUM | Ensure Encryption keys are rotated within a period of 90 days. | accurics.gcp.EKM.139 |
-| Encryption & Key Management | gcp | HIGH | Ensure Encryption keys are rotated within a period of 365 days. | accurics.gcp.EKM.007 |
+| Security Best Practices | gcp | MEDIUM | Ensure Encryption keys are rotated within a period of 90 days. | accurics.gcp.EKM.139 |
+| Security Best Practices | gcp | HIGH | Ensure Encryption keys are rotated within a period of 365 days. | accurics.gcp.EKM.007 |
 
 
 ### google_project_iam_binding
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Identity & Access Management | gcp | MEDIUM | Ensure that IAM users are not assigned the Service Account User or Service Account Token Creator roles at project level. | accurics.gcp.IAM.136 |
-| Identity and Access Management | gcp | HIGH | Ensure that corporate login credentials are used instead of Gmail accounts. | accurics.gcp.IAM.150 |
-
-
+| Identity and Access Management | gcp | HIGH | Ensure that IAM users are not assigned the Service Account User or Service Account Token Creator roles at project level. | accurics.gcp.IAM.136 |
+| Identity and Access Management | gcp | MEDIUM | Ensure that corporate login credentials are used instead of Gmail accounts. | accurics.gcp.IAM.150 |

--- a/content/en/docs/Policies/github.md
+++ b/content/en/docs/Policies/github.md
@@ -3,14 +3,13 @@ title: "GitHub Policies"
 linkTitle: "GitHub Policies"
 weight: 50
 description: >
-      
----
 
+---
 
 ### github_repository
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Identity & Access Management | github | MEDIUM | Repository is Not Private. | accurics.github.IAM.1 |
+| Identity and Access Management | github | MEDIUM | Repository is Not Private. | accurics.github.IAM.1 |
 
 
 ### github_repository_webhook
@@ -23,7 +22,3 @@ description: >
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
 | Encryption and Key Management | github | MEDIUM | Insecure SSL is used for organization webhook. | accurics.github.EKM.1 |
-
-
-
-

--- a/content/en/docs/Policies/k8s.md
+++ b/content/en/docs/Policies/k8s.md
@@ -3,122 +3,76 @@ title: "Kubernetes Policies"
 linkTitle: "Kubernetes Policies"
 weight: 60
 description: >
-      
+
 ---
+
+### kubernetes_endpoint_slice
+| Category | Resource | Severity | Description | Reference ID |
+| -------- | -------- | -------- | ----------- | ------------ |
+| Infrastructure Security | json | LOW | Ensure endpoint slice is not created or updated with loopback addresses as this acts as an attack vector for exploiting CVE-2021-25737 by an authorized user | AC_K8S_0113 |
+
 
 ### kubernetes_service
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | json | MEDIUM | Restrict the use of externalIPs | AC-K8-NS-SE-M-0188 |
-| Network Security | json | MEDIUM | Ensure that the Tiller Service (Helm v2) is deleted | AC-K8-NS-SE-M-0185 |
-| Network Security | json | LOW | Nodeport service can expose the worker nodes as they have public interface | AC-K8-NS-SV-L-0132 |
-| Network Security | json | MEDIUM | Vulnerable to CVE-2020-8554 | AC-K8-NS-SE-M-0188 |
+| Infrastructure Security | json | LOW | Ensure the use of selector is enforced for Kubernetes Ingress or LoadBalancer service | AC_K8S_0114 |
+| Infrastructure Security | json | MEDIUM | Restrict the use of externalIPs | AC-K8-NS-SE-M-0188 |
+| Infrastructure Security | json | MEDIUM | Ensure that the Tiller Service (Helm v2) is deleted | AC-K8-NS-SE-M-0185 |
+| Infrastructure Security | json | LOW | Nodeport service can expose the worker nodes as they have public interface | AC-K8-NS-SV-L-0132 |
+| Infrastructure Security | json | MEDIUM | Vulnerable to CVE-2020-8554 | AC-K8-NS-SE-M-0188 |
 
 
 ### kubernetes_ingress
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | json | HIGH | TLS disabled can affect the confidentiality of the data in transit | AC-K8-NS-IN-H-0020 |
+| Infrastructure Security | json | MEDIUM | TLS disabled can affect the confidentiality of the data in transit | AC-K8-NS-IN-H-0020 |
 
 
 ### kubernetes_pod
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | json | MEDIUM | Containers Should Not Share the Host Network Namespace | AC-K8-NS-PO-M-0164 |
-| Network Security | json | MEDIUM | Image without digest affects the integrity principle of image security | AC-K8-NS-PO-M-0133 |
+| Infrastructure Security | json | MEDIUM | Containers Should Not Share the Host Network Namespace | AC-K8-NS-PO-M-0164 |
+| Infrastructure Security | json | MEDIUM | Image without digest affects the integrity principle of image security | AC-K8-NS-PO-M-0133 |
 | Identity and Access Management | json | HIGH | Minimize Admission of Root Containers | AC-K8-IA-PO-H-0168 |
-| Operational Efficiency | json | Medium | CPU Request Not Set in config file. | AC-K8-OE-PK-M-0155 |
-| Operational Efficiency | json | MEDIUM | Default Namespace Should Not be Used | AC-K8-OE-PO-M-0166 |
-| Network Security | json | HIGH | Do Not Use CAP_SYS_ADMIN Linux Capability | AC-K8-NS-PO-H-0170 |
-| Operational Efficiency | json | Medium | Memory Limits Not Set in config file. | AC-K8-OE-PK-M-0158 |
-| Data Security | json | MEDIUM | Ensure That Tiller (Helm V2) Is Not Deployed | AC-K8-DS-PO-M-0177 |
-| Operational Efficiency | json | LOW | No readiness probe will affect automatic recovery in case of unexpected errors | AC-K8-OE-PO-L-0130 |
+| Security Best Practices | json | Medium | CPU Request Not Set in config file. | AC-K8-OE-PK-M-0155 |
+| Security Best Practices | json | HIGH | Default Namespace Should Not be Used | AC-K8-OE-PO-M-0166 |
+| Infrastructure Security | json | MEDIUM | Do Not Use CAP_SYS_ADMIN Linux Capability | AC-K8-NS-PO-H-0170 |
+| Security Best Practices | json | Medium | Memory Limits Not Set in config file. | AC-K8-OE-PK-M-0158 |
+| Data Protection | json | MEDIUM | Ensure That Tiller (Helm V2) Is Not Deployed | AC-K8-DS-PO-M-0177 |
+| Security Best Practices | json | LOW | No readiness probe will affect automatic recovery in case of unexpected errors | AC-K8-OE-PO-L-0130 |
 | Identity and Access Management | json | MEDIUM | Default seccomp profile not enabled will make the container to make non-essential system calls | AC-K8-IA-PO-M-0141 |
 | Identity and Access Management | json | MEDIUM | Container images with readOnlyRootFileSystem set as false mounts the container root file system with write permissions | AC-K8-IA-PO-M-0140 |
-| Network Security | json | HIGH | Prefer using secrets as files over secrets as environment variables | AC-K8-NS-PO-H-0117 |
-| Network Security | json | MEDIUM | Containers Should Not Share Host IPC Namespace | AC-K8-NS-PO-M-0163 |
-| Network Security | json | MEDIUM | Apply Security Context to Your Pods and Containers | AC-K8-NS-PO-M-0122 |
-| Data Security | json | MEDIUM | Ensure Kubernetes Dashboard Is Not Deployed | AC-K8-DS-PO-M-0176 |
+| Infrastructure Security | json | HIGH | Prefer using secrets as files over secrets as environment variables | AC-K8-NS-PO-H-0117 |
+| Infrastructure Security | json | MEDIUM | Containers Should Not Share Host IPC Namespace | AC-K8-NS-PO-M-0163 |
+| Infrastructure Security | json | MEDIUM | Apply Security Context to Your Pods and Containers | AC-K8-NS-PO-M-0122 |
+| Data Protection | json | MEDIUM | Ensure Kubernetes Dashboard Is Not Deployed | AC-K8-DS-PO-M-0176 |
 | Identity and Access Management | json | HIGH | Allowing hostPaths to mount to Pod arise the probability of getting access to the node's filesystem | AC-K8-IA-PO-H-0138 |
 | Identity and Access Management | json | MEDIUM | Some volume types mount the host file system paths to the pod or container, thus increasing the chance of escaping the container to access the host | AC-K8-IA-PO-M-0143 |
-| Identity and Access Management | json | HIGH | Allowing the pod to make system level calls provide access to host/node sensitive information | AC-K8-IA-PO-H-0137 |
-| Operational Efficiency | json | MEDIUM | AlwaysPullImages plugin is not set | AC-K8-OE-PK-M-0034 |
+| Identity and Access Management | json | MEDIUM | Allowing the pod to make system level calls provide access to host/node sensitive information | AC-K8-IA-PO-H-0137 |
+| Data Protection | json | MEDIUM | Vulnerable to CVE-2020-8555 (affected version of kube-controller-manager: v1.18.0, v1.17.0 - v1.17.4, v1.16.0 - v1.16.8, and v1.15.11 | AC-K8-DS-PO-M-0143 |
+| Compliance Validation | json | MEDIUM | AlwaysPullImages plugin is not set | AC-K8-OE-PK-M-0034 |
 | Identity and Access Management | json | MEDIUM | Unmasking the procMount will allow more information than is necessary to the program running in the containers spawned by k8s | AC-K8-IA-PO-M-0139 |
 | Identity and Access Management | json | MEDIUM | AppArmor profile not set to default or custom profile will make the container vulnerable to kernel level threats | AC-K8-IA-PO-M-0135 |
 | Identity and Access Management | json | MEDIUM | Containers Should Not Share Host Process ID Namespace | AC-K8-IA-PO-M-0162 |
-| Network Security | json | MEDIUM | Containers Should Run as a High UID to Avoid Host Conflict | AC-K8-NS-PO-M-0182 |
+| Infrastructure Security | json | MEDIUM | Containers Should Run as a High UID to Avoid Host Conflict | AC-K8-NS-PO-M-0182 |
 | Identity and Access Management | json | MEDIUM | Minimize the admission of containers with the NET_RAW capability | AC-K8-IA-PS-M-0112 |
-| Operational Efficiency | json | LOW | No liveness probe will ensure there is no recovery in case of unexpected errors | AC-K8-OE-PO-L-0129 |
-| Operational Efficiency | json | LOW | No tag or container image with :Latest tag makes difficult to rollback and track | AC-K8-OE-PO-L-0134 |
-| Operational Efficiency | json | Medium | Memory Request Not Set in config file. | AC-K8-OE-PK-M-0157 |
-| Cloud Assets Management | json | HIGH | Containers Should Not Run with AllowPrivilegeEscalation | AC-K8-CA-PO-H-0165 |
+| Security Best Practices | json | LOW | No liveness probe will ensure there is no recovery in case of unexpected errors | AC-K8-OE-PO-L-0129 |
+| Security Best Practices | json | LOW | No tag or container image with :Latest tag makes difficult to rollback and track | AC-K8-OE-PO-L-0134 |
+| Security Best Practices | json | Medium | Memory Request Not Set in config file. | AC-K8-OE-PK-M-0157 |
+| Compliance Validation | json | HIGH | Containers Should Not Run with AllowPrivilegeEscalation | AC-K8-CA-PO-H-0165 |
 | Identity and Access Management | json | HIGH | Minimize the admission of privileged containers | AC-K8-IA-PO-H-0106 |
-| Operational Efficiency | json | Medium | CPU Limits Not Set in config file. | AC-K8-OE-PK-M-0156 |
-| Network Security | json | MEDIUM | Restrict Mounting Docker Socket in a Container | AC-K8-NS-PO-M-0171 |
+| Security Best Practices | json | Medium | CPU Limits Not Set in config file. | AC-K8-OE-PK-M-0156 |
+| Infrastructure Security | json | MEDIUM | Restrict Mounting Docker Socket in a Container | AC-K8-NS-PO-M-0171 |
 | Identity and Access Management | json | MEDIUM | Ensure that Service Account Tokens are only mounted where necessary | AC-K8-IA-PO-M-0105 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.120 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.116 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.117 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.106 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.110 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.111 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.107 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.112 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.108 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.109 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.105 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.113 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.118 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.114 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.115 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.119 |
-| Data Security | json | MEDIUM | Vulnerable to CVE-2020-8555 (affected version of kube-controller-manager: v1.18.0, v1.17.0 - v1.17.4, v1.16.0 - v1.16.8,< v1.15.11 | AC-K8-DS-PO-M-0143 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.64 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.72 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.68 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.69 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.65 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.58 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.62 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.63 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.59 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.60 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.61 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.57 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.70 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.66 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.67 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.71 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.81 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.78 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.74 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.75 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.79 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.80 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.87 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.86 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.73 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.85 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.84 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.88 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.83 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.76 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.77 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.82 |
 
 
 ### kubernetes_role
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Identity and Access Management | json | HIGH | Ensure that default service accounts are not actively used | AC-K8-IA-RO-H-0104 |
+| Identity and Access Management | json | HIGH | Ensure that default service accounts are not actively used in Kubernetes Role | AC-K8-IA-RO-H-0104 |
 
 
 ### kubernetes_namespace
 | Category | Resource | Severity | Description | Reference ID |
 | -------- | -------- | -------- | ----------- | ------------ |
-| Operational Efficiency | kubernetes | LOW | The default namespace should not be used | accurics.kubernetes.OPS.462 |
-| Operational Efficiency | kubernetes | LOW | The default namespace should not be used | accurics.kubernetes.OPS.460 |
-| Operational Efficiency | kubernetes | LOW | The default namespace should not be used | accurics.kubernetes.OPS.461 |
-| Operational Efficiency | json | LOW | No owner for namespace affects the operations | AC-K8-OE-NS-L-0128 |
-
-
+| Security Best Practices | json | LOW | No owner for namespace affects the operations | AC-K8-OE-NS-L-0128 |

--- a/content/en/docs/Policies/policies.md
+++ b/content/en/docs/Policies/policies.md
@@ -14,9 +14,7 @@ The first time using Terrascan, if the `-p` flag is not specified, Terrascan wil
 
 ## Ignoring Policies on a scan
 
-Terrascan keeps a copy of policies on your local filesystem on the `~/.terrascan/pkg/policies/opa/rego` directory. You can also specify a particular directory with rego policies to scan by using the `-p` flag. To ignore a particular policy from a scan, you can remove the rule `.json` file for the policy you would like to ignore from the scan. Note that this policy would be ignored until the `.json` file is added again to the directory.
-
-In a future enhancement, Terrascan will have a better way to ignore individual policies from scans without having to modify the policies stored in the file system [#367](https://github.com/accurics/terrascan/issues/367).
+Terrascan keeps a copy of policies on your local filesystem on the `~/.terrascan/pkg/policies/opa/rego` directory. You can also specify a particular directory with rego policies to scan by using the `-p` flag. Terrascan allows you to ignore policies from scans by using the [--skip-rules](../usage/command_line_mode/#list-of-options-for-scan-command) flag or using [in-file instrumentation](../usage/in-file_instrumentation/) to skip policies on a particular resource.
 
 ## Adding policies
 
@@ -121,15 +119,3 @@ Here's an example of the contents of a rule file:
 | ruleReferenceId      | Unique ID of the rule in the format `<cloud-provider>.<resource-type>.<rule-category>.<severity>.<next-available-rule-number>` |
 | category            | Descriptive category for this rule    |
 | version             | Version number for the rule/rego      |
-
---8<-- "docs/policies/aws.md"
-
---8<-- "docs/policies/azure.md"
-
---8<-- "docs/policies/gcp.md"
-
---8<-- "docs/policies/github.md"
-
---8<-- "docs/policies/k8s.md"
-
---8<-- "docs/policies/github.md"

--- a/scripts/document_policies.py
+++ b/scripts/document_policies.py
@@ -1,0 +1,37 @@
+# This scrip documents the Rego policies in the
+# policies directory of the Terrascan repository.
+# To use it, run the script from the root of
+# Terrscan's repository and copy the generated files
+# into the runterrscan.io repo.
+
+import os
+import json
+
+def dir_size(dir):
+    policy_types = []
+    for file in os.listdir(dir):
+        if not file.endswith(".go"):
+            policy_types.append(file)
+    for policy_type in policy_types:
+        with open(f"docs/policies/{policy_type}.md", "w") as f:
+            f.write(f"\n")
+            for resource_type in os.listdir(os.path.join(dir,policy_type)):
+                f.write(f"### {resource_type}\n")
+                f.write("| Category | Resource | Severity | Description | Reference ID |\n")
+                f.write("| -------- | -------- | -------- | ----------- | ------------ |\n")
+                for (dirpath, dirs, files) in os.walk(os.path.join(dir, policy_type, resource_type)):
+                    for filename in files:
+                        if '.json' in filename:
+                            with open(os.path.join(dirpath,filename)) as p:
+                                policy = json.load(p)
+                                category = policy['category']
+                                resource = filename.split('.')[1]
+                                severity = policy['severity']
+                                description = policy['description'].replace('\n','')
+                                reference_id = policy['reference_id']
+                                f.write(f"| {category} | {resource} | {severity} | {description} | {reference_id} |\n")
+                f.write("\n\n")
+
+if __name__ == '__main__':
+    policy_dir = os.path.join(os.getcwd(), "pkg", "policies", "opa", "rego")
+    dir_size(policy_dir)


### PR DESCRIPTION
This PR contains docs updates corresponding to the latest Terrascan changes including:

- Support for Kustomize v2 & v3
- New exit codes
- Latest policy docs
- Integration with container registries for fetching vulnerability info as part of Terrscan results