### PR TITLE
add script (and associated Dockerfile) for dev test server

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,11 @@
+FROM ubuntu
+
+RUN apt update
+RUN DEBIAN_FRONTEND='noninteractive' apt-get -y install tzdata
+RUN apt install -y git npm hugo
+
+WORKDIR /app
+
+EXPOSE 1313
+
+CMD sh -c "cd themes/docsy && git submodule update -f --init --recursive && npm install postcss-cli && cd ../.. && hugo server -DF --bind 0.0.0.0"

--- a/localdev.sh
+++ b/localdev.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# This script builds a container image within which a development server
+# will run, then launches a container to build the working directory and
+# serve it on http://localhost:1313/.
+#
+# Usage:
+# $ git clone https://github.com/accurics/runterrascan.io
+# $ ./localdev.sh
+# <Open http://localhost:1313/ in browser>
+# <changes to working directory will hot reload in the dev server>
+#
+# Prerequisites: Docker
+
+docker build -t runterrascan-devserver -f Dockerfile.dev .
+
+docker run --name runterrascan-devserver --rm -it -e HUGO_ENV=production -v "$(pwd):/app" -p 1313:1313 runterrascan-devserver


### PR DESCRIPTION
Start local test server with ./localdev.sh (must have Docker installed locally)
Test server available over HTTP on port 1313